### PR TITLE
Use CakePlugin::loaded sine App::objects also shows non-loaded plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 env:
   - CAKE_VERSION=master
-  - CAKE_VERSION=2.5
+  - CAKE_VERSION=2.6
 
 before_script:
   - git clone --depth 1 --branch $CAKE_VERSION git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp
@@ -33,6 +33,8 @@ before_script:
       'persistent' => false,
     );
     }" > app/Config/database.php
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ]; then composer global require 'phpunit/phpunit=3.7.33'; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ]; then ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit ./vendors/PHPUnit; fi"
   - cd app
 script:
   - ../lib/Cake/Console/cake test Queue AllQueue --stderr

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -49,7 +49,7 @@ class QueueShell extends AppShell {
 			}
 			$this->tasks = $res;
 		}
-		$plugins = App::objects('plugin');
+		$plugins = CakePlugin::loaded();
 		foreach ($plugins as $plugin) {
 			$pluginPaths = App::path('Console/Command/Task', $plugin);
 			foreach ($pluginPaths as $pluginPath) {


### PR DESCRIPTION
I've seen cases where App::objects also shows plugins which are not loaded. This results in very odd behavior.

We should better use CakePlugin::loaded since this gets a list of all loaded plugins.
