### PR TITLE
patch sql encoding bug in Queue Plugin

### DIFF
--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -225,12 +225,13 @@ class QueuedTask extends QueueAppModel {
  * @return boolean Success
  */
 	public function markJobFailed($id, $failureMessage = null) {
+		$db = $this->getDataSource();
 		$fields = array(
 			$this->alias . '.failed' => $this->alias . '.failed + 1',
-			$this->alias . '.failure_message' => $failureMessage,
+			$this->alias . '.failure_message' => $db->value($failureMessage),
 		);
 		$conditions = array(
-			$this->alias . '.id' => $id
+			$this->alias . '.id' => (integer) $id
 		);
 		return $this->updateAll($fields, $conditions);
 	}


### PR DESCRIPTION
The failureMessage is not escaped for the DB when trying to write the failure message in markJobFailed. 
