### PR TITLE
Update QueueExecuteTask.php

### DIFF
--- a/Console/Command/Task/QueueExecuteTask.php
+++ b/Console/Command/Task/QueueExecuteTask.php
@@ -71,8 +71,8 @@ class QueueExecuteTask extends AppShell {
 		} else {
 
 			$data = array(
-				'command' => $this->args[1],
-				'params' => array_slice($this->args, 2)
+				'command' => $this->args[0],
+				'params' => array_slice($this->args, 1)
 			);
 			if ($this->QueuedTask->createJob('Execute', $data)) {
 				$this->out('Job created');


### PR DESCRIPTION
The arguments for a shell are indexed from 0. This change allows jobs with no params and one param to be added. Previously only jobs with 2 or more params would be added.
