### PR TITLE
Typo fix, README additions, Config/queue.php comments

### DIFF
--- a/Config/queue.php
+++ b/Config/queue.php
@@ -1,14 +1,41 @@
 <?php
 
+/**
+ * This file configures default behavior for all workers
+ *
+ * To modify these parameters, copy this file into your own CakePHP APP/Config directory.
+ *
+ */
+
+
 $config['Queue'] = array(
+	// seconds to sleep() when no executable job is found
 	'sleeptime' => 10,
-	'gcprop' => 10,
+
+	// probability in percent of a old job cleanup happening
+	'gcprob' => 10,
+
+	// time (in seconds) after which a job is requeued if the worker doesn't report back
 	'defaultworkertimeout' => 120,
+
+	// number of retries if a job fails or times out.
 	'defaultworkerretries' => 4,
+
+	// seconds of running time after which the worker will terminate (0 = unlimited)
 	'workermaxruntime' => 0,
+
+	// amount of time that a worker will attempt to spend on a cleanup job before timing out
 	'cleanuptimeout' => 2000,
+
+	// instruct a Workerprocess quit when there are no more tasks for it to execute (true = exit, false = keep running)
 	'exitwhennothingtodo' => false,
+
+	// pid file path directory (by default goes to the app/tmp/queue folder)
 	'pidfilepath' => TMP . 'queue' . DS,
+
+	// determine whether logging is enabled
 	'log' => true,
-	'notify' => 'tmp' // Set to false to disable (tmp = file in TMP dir)
+
+	// set to false to disable (tmp = file in TMP dir)
+	'notify' => 'tmp'
 );

--- a/Console/Command/CronShell.php
+++ b/Console/Command/CronShell.php
@@ -73,7 +73,7 @@ class CronShell extends AppShell {
 			'cleanuptimeout' => MONTH,
 		/*
 			'sleeptime' => 10,
-			'gcprop' => 10,
+			'gcprob' => 10,
 			'defaultworkertimeout' => 120,
 			'defaultworkerretries' => 4,
 
@@ -198,7 +198,7 @@ class CronShell extends AppShell {
 					$exit = true;
 					$this->out('Reached runtime of ' . (time() - $starttime) . ' Seconds (Max ' . Configure::read('Queue.maxruntime') . '), terminating.');
 				}
-				if ($exit || rand(0, 100) > (100 - Configure::read('Queue.gcprop'))) {
+				if ($exit || rand(0, 100) > (100 - Configure::read('Queue.gcprob'))) {
 					$this->out('Performing Old job cleanup.');
 					$this->CronTask->cleanOldJobs();
 				}

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -237,7 +237,7 @@ class QueueShell extends AppShell {
 					$this->_exit = true;
 					$this->out('Reached runtime of ' . (time() - $starttime) . ' Seconds (Max ' . Configure::read('Queue.workermaxruntime') . '), terminating.');
 				}
-				if ($this->_exit || rand(0, 100) > (100 - Configure::read('Queue.gcprop'))) {
+				if ($this->_exit || rand(0, 100) > (100 - Configure::read('Queue.gcprob'))) {
 					$this->out('Performing Old job cleanup.');
 					$this->QueuedTask->cleanOldJobs();
 				}

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ You may create a file called "queue.php" inside your 'APP/Config' folder (NOT th
 
 		$config['Queue']['sleeptime'] = 10;
 
-- Propability in percent of a old job cleanup happening
+- Probability in percent of a old job cleanup happening
 
-		$config['Queue']['gcprop'] = 10;
+		$config['Queue']['gcprob'] = 10;
 
 - Default timeout after which a job is requeued if the worker doesn't report back
 
@@ -108,8 +108,10 @@ Run the following using the CakePHP shell:
 	The worker will always try to find jobs matching its installed Tasks.
 
 
-Most tasks you will not trigger from the console, but the actual APP code.
-Use the model access for QueueTask to do that:
+Some tasks will not be triggered from the console, but from the APP code.
+You will need to use the model access for QueueTask and the createJob() function to do this.
+
+The `createJob()` function takes two arguments.  The first argument is the name of the type of job that you are creating.  The second argument can take any format and will be passed as a parameter to the `run()` function of the worker.
 
 For sending emails, for example:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Modified by Mark Scherer (dereuromark)
 - Some minor fixes
 - Added crontasks (as a different approach on specific problems)
 - Possible (optional) Tools Plugin dependencies for frontend access via /admin/queue
-
-New:
 - Config key "queue" is now "Queue" ($config['Queue'][...])
+
+Added by Christian Charukiewicz (charukiewicz):
+- Configuration option 'gcprop' is now 'gcprob'
+- Fixed typo in README and variable name (Propability -> Probability)
+- Added a few lines about createJob() usage to README
+- Added comments to queue.php explaining configuration options
 
 
 ## Background:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![License](https://poser.pugx.org/dereuromark/cakephp-queue/license.png)](https://packagist.org/packages/dereuromark/cakephp-queue)
 [![Total Downloads](https://poser.pugx.org/dereuromark/cakephp-queue/d/total.png)](https://packagist.org/packages/dereuromark/cakephp-queue)
 
-Modified by Mark Scherer (dereuromark)
+Modified by Mark Scherer ([dereuromark](https://github.com/dereuromark))
 - CakePHP2.x support
 - Some minor fixes
 - Added crontasks (as a different approach on specific problems)
 - Possible (optional) Tools Plugin dependencies for frontend access via /admin/queue
 - Config key "queue" is now "Queue" ($config['Queue'][...])
 
-Added by Christian Charukiewicz (charukiewicz):
+Added by Christian Charukiewicz ([charukiewicz](https://github.com/charukiewicz)):
 - Configuration option 'gcprop' is now 'gcprob'
 - Fixed typo in README and variable name (Propability -> Probability)
 - Added a few lines about createJob() usage to README

--- a/Test/Case/Console/Command/QueueShellTest.php
+++ b/Test/Case/Console/Command/QueueShellTest.php
@@ -25,7 +25,7 @@ class QueueShellTest extends MyCakeTestCase {
 
 		Configure::write('Queue', array(
 			'sleeptime' => 2,
-			'gcprop' => 10,
+			'gcprob' => 10,
 			'defaultworkertimeout' => 3,
 			'defaultworkerretries' => 1,
 			'workermaxruntime' => 5,


### PR DESCRIPTION
Hello,

I am making this pull request to propose adding a few minor tweaks I made to a few areas of this plugin that I think will improve its quality.  The changes are as follows:

1.  Renamed the configuration variable `gcprop` to `gcprob` in the entire plugin.

    I assume that `gcprop` stands for "garbage collection propability".  Unfortunately "propability" is a typo, the actual world is "probability" so some people may find the name of the configuration option confusing.

2.  Fixed the "propability" typo in the README (it is now "probability").

    Self explanatory.

3.  Added a few lines about how to use `createJob()` to the README.

    When I first read the README, I was not exactly sure how to use `createJob()`.  I had to look at the example files and try it out myself to understand what the two parameters meant.  I added an explanation in the README to help clear up any initial confusion anyone else may have.

4.  Added comments to the configuration file (Config/queue.php).

    The purpose of this is to help people understand what the individual options mean without having to open the README again.

All of these changes have been documented in the first few lines of the README as well.  I have tested this in my own project and everything works as it did before.  Users will have to change their `gcprop` to `gcprob` in their APP/Config/queue.php file if they already have that line.  If they do not, it will not break the project but revert to the default value.