### PR TITLE
Add progress field

### DIFF
--- a/Config/Schema/queue.php
+++ b/Config/Schema/queue.php
@@ -71,6 +71,12 @@ class QueueSchema extends CakeSchema {
 			'null' => true,
 			'default' => null
 		],
+		'progress' => [
+			'type' => 'float',
+			'null' => true,
+			'default' => null,
+			'length' => '3,2'
+		],
 		'completed' => [
 			'type' => 'datetime',
 			'null' => true,

--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -49,6 +49,7 @@ class QueueSchema extends CakeSchema {
 		'created' => ['type' => 'datetime', 'null' => false, 'default' => null],
 		'notbefore' => ['type' => 'datetime', 'null' => true, 'default' => null],
 		'fetched' => ['type' => 'datetime', 'null' => true, 'default' => null],
+		'progress' => ['type' => 'float', 'null' => true, 'default' => null, 'length' => '3,2'],
 		'completed' => ['type' => 'datetime', 'null' => true, 'default' => null],
 		'failed' => ['type' => 'integer', 'null' => false, 'default' => '0', 'length' => 3],
 		'failure_message' => ['type' => 'text', 'null' => true, 'default' => null, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'],

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -355,6 +355,7 @@ class QueuedTask extends QueueAppModel {
 			$query['fields'] = [
 				$this->alias . '.reference',
 				'(CASE WHEN ' . $this->alias . '.notbefore > NOW() THEN \'NOT_READY\' WHEN ' . $this->alias . '.fetched IS null THEN \'NOT_STARTED\' WHEN ' . $this->alias . '.fetched IS NOT null AND ' . $this->alias . '.completed IS null AND ' . $this->alias . '.failed = 0 THEN \'IN_PROGRESS\' WHEN ' . $this->alias . '.fetched IS NOT null AND ' . $this->alias . '.completed IS null AND ' . $this->alias . '.failed > 0 THEN \'FAILED\' WHEN ' . $this->alias . '.fetched IS NOT null AND ' . $this->alias . '.completed IS NOT null THEN \'COMPLETED\' ELSE \'UNKNOWN\' END) AS status',
+				$this->alias . '.progress',
 				$this->alias . '.failure_message'
 			];
 			if (isset($query['conditions']['exclude'])) {
@@ -380,6 +381,9 @@ class QueuedTask extends QueueAppModel {
 				'reference' => $result[$this->alias]['reference'],
 				'status' => $result[0]['status']
 			];
+			if (!empty($result[$this->alias]['progress'])) {
+				$results[$k]['progress'] = $result[$this->alias]['progress'];
+			}
 			if (!empty($result[$this->alias]['failure_message'])) {
 				$results[$k]['failure_message'] = $result[$this->alias]['failure_message'];
 			}


### PR DESCRIPTION
There is an updateProgress() model method but the field wasn’t included in the schema.

I’m guessing it should also include the field in the _findProgress() method.

This could be a precursor to introducing a progress bar for the console output.