### PR TITLE
Add $id to arguments of run method in example tasks

### DIFF
--- a/Console/Command/Task/QueueEmailTask.php
+++ b/Console/Command/Task/QueueEmailTask.php
@@ -56,9 +56,10 @@ class QueueEmailTask extends AppShell {
  * QueueEmailTask::run()
  *
  * @param mixed $data Job data
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  */
-	public function run($data) {
+	public function run($data, $id = null) {
 		if (!isset($data['settings'])) {
 			$this->err('Queue Email task called without settings data.');
 			return false;

--- a/Console/Command/Task/QueueExampleTask.php
+++ b/Console/Command/Task/QueueExampleTask.php
@@ -89,9 +89,10 @@ class QueueExampleTask extends AppShell {
  * The return parameter will determine, if the task will be marked completed, or be requeued.
  *
  * @param array $data The array passed to QueuedTask->createJob()
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  */
-	public function run($data) {
+	public function run($data, $id = null) {
 		$this->hr();
 		$this->out('CakePHP Queue Example task.');
 		$this->hr();

--- a/Console/Command/Task/QueueExecuteTask.php
+++ b/Console/Command/Task/QueueExecuteTask.php
@@ -89,9 +89,10 @@ class QueueExecuteTask extends AppShell {
  * The return parameter will determine, if the task will be marked completed, or be requeued.
  *
  * @param array $data The array passed to QueuedTask->createJob()
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  */
-	public function run($data) {
+	public function run($data, $id = null) {
 		$command = escapeshellcmd($data['command']);
 		if (!empty($data['params'])) {
 			$command .= ' ' . implode(' ', $data['params']);

--- a/Console/Command/Task/QueueLongExampleTask.php
+++ b/Console/Command/Task/QueueLongExampleTask.php
@@ -85,7 +85,7 @@ class QueueLongExampleTask extends AppShell {
  * The return parameter will determine, if the task will be marked completed, or be requeued.
  *
  * @param array $data The array passed to QueuedTask->createJob()
- * @param int $id The id
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  * @throws RuntimeException when seconds are 0;
  */

--- a/Console/Command/Task/QueueRetryExampleTask.php
+++ b/Console/Command/Task/QueueRetryExampleTask.php
@@ -105,9 +105,10 @@ class QueueRetryExampleTask extends AppShell {
  * The return parameter will determine, if the task will be marked completed, or be requeued.
  *
  * @param array $data The array passed to QueuedTask->createJob()
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  */
-	public function run($data) {
+	public function run($data, $id = null) {
 		$count = (int)file_get_contents($this->file);
 
 		$this->hr();

--- a/Console/Command/Task/QueueSuperExampleTask.php
+++ b/Console/Command/Task/QueueSuperExampleTask.php
@@ -88,9 +88,10 @@ class QueueSuperExampleTask extends AppShell {
  * The return parameter will determine, if the task will be marked completed, or be requeued.
  *
  * @param array $data The array passed to QueuedTask->createJob()
+ * @param int $id The id of the QueuedTask
  * @return bool Success
  */
-	public function run($data) {
+	public function run($data, $id = null) {
 		$this->hr();
 		$this->out('CakePHP Queue SuperExample task.');
 		$this->hr();


### PR DESCRIPTION
QueueShell::runworker() passes the id of the QueuedTask when it calls
the run method on the task. The QueueLongExampleTask included the
argument but the rest were missing.