### PR TITLE
Worker timestamp option

### DIFF
--- a/Config/queue.php
+++ b/Config/queue.php
@@ -37,5 +37,8 @@ $config['Queue'] = [
 	'log' => true,
 
 	// set to false to disable (tmp = file in TMP dir)
-	'notify' => 'tmp'
+	'notify' => 'tmp',
+
+    // prints a timestamp each time a worker begins looking for a job
+    'workertimestamp' => false
 ];

--- a/Config/queue.php
+++ b/Config/queue.php
@@ -39,6 +39,6 @@ $config['Queue'] = [
 	// set to false to disable (tmp = file in TMP dir)
 	'notify' => 'tmp',
 
-    // prints a timestamp each time a worker begins looking for a job
-    'workertimestamp' => false
+	// prints a timestamp each time a worker begins looking for a job
+	'workertimestamp' => false
 ];

--- a/Config/queue.php
+++ b/Config/queue.php
@@ -38,7 +38,4 @@ $config['Queue'] = [
 
 	// set to false to disable (tmp = file in TMP dir)
 	'notify' => 'tmp',
-
-	// prints a timestamp each time a worker begins looking for a job
-	'workertimestamp' => false
 ];

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -200,11 +200,11 @@ class QueueShell extends AppShell {
 				touch($pidFilePath . $pidFileName);
 			}
 			$this->_log('runworker', isset($pid) ? $pid : null);
-            if (Configure::read('Queue.workertimestamp')) {
-                $this->out('['.date('Y-m-d H:i:s').'] Looking for Job....');
-            } else {
-                $this->out('Looking for Job....');
-            }
+			if (Configure::read('Queue.workertimestamp')) {
+ 				$this->out('['.date('Y-m-d H:i:s').'] Looking for Job....');
+			} else {
+ 				$this->out('Looking for Job....');
+			}
 			$data = $this->QueuedTask->requestJob($this->_getTaskConf(), $group);
 			if ($this->QueuedTask->exit === true) {
 				$this->_exit = true;

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -200,7 +200,11 @@ class QueueShell extends AppShell {
 				touch($pidFilePath . $pidFileName);
 			}
 			$this->_log('runworker', isset($pid) ? $pid : null);
-			$this->out('Looking for Job....');
+            if (Configure::read('Queue.workertimestamp')) {
+                $this->out('['.date('Y-m-d H:i:s').'] Looking for Job....');
+            } else {
+                $this->out('Looking for Job....');
+            }
 			$data = $this->QueuedTask->requestJob($this->_getTaskConf(), $group);
 			if ($this->QueuedTask->exit === true) {
 				$this->_exit = true;

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -200,11 +200,7 @@ class QueueShell extends AppShell {
 				touch($pidFilePath . $pidFileName);
 			}
 			$this->_log('runworker', isset($pid) ? $pid : null);
-			if (Configure::read('Queue.workertimestamp')) {
- 				$this->out('['.date('Y-m-d H:i:s').'] Looking for Job....');
-			} else {
- 				$this->out('Looking for Job....');
-			}
+			$this->out('['.date('Y-m-d H:i:s').'] Looking for Job....');
 			$data = $this->QueuedTask->requestJob($this->_getTaskConf(), $group);
 			if ($this->QueuedTask->exit === true) {
 				$this->_exit = true;


### PR DESCRIPTION
I added a config option for worker timestamps to be printed each time they begin looking for a job.

By default this option is false, but can be turned on to help with debugging or improve logging.

At the moment a worker will always print:

`Looking for Job....`

But with the `workertimestamp` option set to `true`, workers will print something like:

`[2015-05-08 09:53:04] Looking for Job....`