### PR TITLE
Fix failed increment

### DIFF
--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -332,7 +332,7 @@ class QueuedTasksTable extends Table {
 			$failureMessage = $db->failure_message;
 		}
 		$fields = [
-			'failed' => 'failed + 1',
+			'failed = failed + 1',
 			'failure_message' => $failureMessage,
 		];
 		$conditions = [


### PR DESCRIPTION
This fixes updating of the failed count in the queued_tasks table in my case. I'm running CakePHP 3 and MySQL.