### PR TITLE
Fix migration errors

### DIFF
--- a/config/Migrations/20150425180802_init.php
+++ b/config/Migrations/20150425180802_init.php
@@ -48,5 +48,6 @@ SQL;
 	 * @return void
 	 */
 	public function down() {
+		$this->query('DROP TABLE IF EXISTS `queued_tasks`;');
 	}
 }

--- a/config/Migrations/20150511062806_fixmissing.php
+++ b/config/Migrations/20150511062806_fixmissing.php
@@ -19,22 +19,7 @@ class Fixmissing extends AbstractMigration {
 		$table = $this->table('queued_tasks');
 		$table->addColumn('status', 'string', array('limit' => 255))
 			->renameColumn('group', 'task_group')
-			->create();
+			->update();
 	}
 
-	/**
-	 * Migrate Up.
-	 *
-	 * @return void
-	 */
-	public function up() {
-	}
-
-	/**
-	 * Migrate Down.
-	 *
-	 * @return void
-	 */
-	public function down() {
-	}
 }


### PR DESCRIPTION
While trying to execute migration of this plugin I noticed these errors.

In initial migration, down() method was empty, so we can't rollback the migration.

In second migration, update() should be called instead of create().