### PR TITLE
class not found fix

### DIFF
--- a/src/Shell/Task/QueueSuperExampleTask.php
+++ b/src/Shell/Task/QueueSuperExampleTask.php
@@ -6,6 +6,7 @@
  */
 namespace Queue\Shell\Task;
 
+use Cake\ORM\TableRegistry;
 use Queue\Shell\Task\QueueTask;
 
 /**


### PR DESCRIPTION
To obtain the fatal error try:

```cake queue add SuperExample```
```cake queue runworker```