### PR TITLE
Improvements for it to be working on MySQL that is not MariaDB fork

### DIFF
--- a/config/Migrations/20150911132343_improvements_for_mysql.php
+++ b/config/Migrations/20150911132343_improvements_for_mysql.php
@@ -1,0 +1,35 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ImprovementsForMysql extends AbstractMigration {
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     */
+    public function change() {
+        $table = $this->table('queued_tasks');
+
+        $table->changeColumn('id', 'integer', [
+            'length' => 11,
+            'null' => false,
+            'default' => null,
+        ]);
+
+        $table->changeColumn('jobtype', 'string', [
+            'length' => 45,
+            'null' => false,
+            'default' => null,
+        ]);
+
+        $table->changeColumn('status', 'string', [
+           'length' => 255,
+            'null' => false,
+            'default' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
Hi! Was having issues with this version of mysql

```
$ mysql --version
mysql  Ver 14.14 Distrib 5.6.24, for debian-linux-gnu (x86_64) using  EditLine wrapper
```

This is fixed by this.

It wouldn't even touch the table, because no default value was set for the column `status` - I just figured I could as well fix the other ones... :smile: 