### PR TITLE
Fix unit tests

### DIFF
--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -4,6 +4,7 @@ namespace Queue\Model\Table;
 use Cake\Core\Configure;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
+use Cake\I18n\Time;
 
 /**
  * QueuedTask for queued tasks.
@@ -73,7 +74,7 @@ class QueuedTasksTable extends Table {
 			'reference' => $reference,
 		];
 		if ($notBefore !== null) {
-			$data['notbefore'] = strtotime($notBefore);
+			$data['notbefore'] = new Time($notBefore);
 		}
 		$queuedTask = $this->newEntity($data);
 		if ($queuedTask->errors()) {

--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -204,13 +204,13 @@ class QueuedTasksTable extends Table {
 				'AND' => [
 					[
 						'OR' => [
-							'notbefore <' => time(),
+							'notbefore <' => new Time(),
 							'notbefore IS' => null,
 						],
 					],
 					[
 						'OR' => [
-							'fetched <' => time() - $task['timeout'],
+							'fetched <' => (new Time())->modify(sprintf('-%d seconds', $task['timeout'])),
 							'fetched IS' => null,
 						],
 					],

--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -266,7 +266,7 @@ class QueuedTasksTable extends Table {
 			$this->save($data, ['fieldList' => ['id', 'failed', 'failure_message']]);
 		}
 		//save last fetch by type for Rate Limiting.
-		$this->rateHistory[$data['jobtype']] = time();
+		$this->rateHistory[$data['jobtype']] = (new Time())->toUnixString() ;
 		return $data;
 	}
 

--- a/tests/TestCase/Model/Table/QueuedTasksTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedTasksTableTest.php
@@ -9,6 +9,7 @@ namespace Queue\Test\TestCase\Model\Table;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\I18n\Time;
 
 /**
  * Queue\Model\Table\QueuedTasksTable Test Case
@@ -215,9 +216,9 @@ class QueuedTasksTableTest extends TestCase {
 		$this->assertTrue((bool)$this->QueuedTasks->createJob('task1', [], '+ 1 Day'));
 		$this->assertTrue((bool)$this->QueuedTasks->createJob('task1', [], '2009-07-01 12:00:00'));
 		$data = $this->QueuedTasks->find('all')->toArray();
-		$this->assertWithinRange(strtotime('+ 1 Min'), $data[0]['notbefore']->toUnixString(), 60);
-		$this->assertWithinRange(strtotime('+ 1 Day'), $data[1]['notbefore']->toUnixString(), 60);
-		$this->assertWithinRange(strtotime('2009-07-01 12:00:00'), $data[2]['notbefore']->toUnixString(), 60);
+		$this->assertWithinRange((new Time('+ 1 Min'))->toUnixString(), $data[0]['notbefore']->toUnixString(), 60);
+		$this->assertWithinRange((new Time('+ 1 Day'))->toUnixString(), $data[1]['notbefore']->toUnixString(), 60);
+		$this->assertWithinRange((new Time('2009-07-01 12:00:00'))->toUnixString(), $data[2]['notbefore']->toUnixString(), 60);
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/QueuedTasksTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedTasksTableTest.php
@@ -292,7 +292,7 @@ class QueuedTasksTableTest extends TestCase {
 				'name' => 'task1',
 				'timeout' => 101,
 				'retries' => 2,
-				'rate' => 1,
+				'rate' => 2,
 			],
 			'dummytask' => [
 				'name' => 'dummytask',
@@ -324,7 +324,7 @@ class QueuedTasksTableTest extends TestCase {
 		$this->assertEquals('dummytask', $tmp['jobtype']);
 		$this->assertNull(unserialize($tmp['data']));
 
-		usleep(500000);
+		usleep(100000);
 		//and again.
 		$this->QueuedTasks->clearKey();
 		$tmp = $this->QueuedTasks->requestJob($capabilities);
@@ -332,7 +332,7 @@ class QueuedTasksTableTest extends TestCase {
 		$this->assertNull(unserialize($tmp['data']));
 
 		//Then some time passes
-		sleep(1);
+		sleep(2);
 
 		//Now we should get task1-2
 		$this->QueuedTasks->clearKey();
@@ -347,7 +347,7 @@ class QueuedTasksTableTest extends TestCase {
 		$this->assertNull(unserialize($tmp['data']));
 
 		//Then some more time passes
-		sleep(1);
+		sleep(2);
 
 		//Now we should get task1-3
 		$this->QueuedTasks->clearKey();


### PR DESCRIPTION
I have fixed the unit tests in the 3.x branch so I get all passes.  In addition to the intermittent rate-limiting issues you mentioned in #71 I was also encountering other failures that I believe stemmed from timestamp inconsistencies, which I was able to fix by using CakePHP's Time() class.