### PR TITLE
add new transport

### DIFF
--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Mark Scherer
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Queue\Mailer\Transport;
+
+use Cake\Mailer\AbstractTransport;
+use Cake\Mailer\Email;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Send mail using Queue plugin
+ */
+class SimpleQueueTransport extends AbstractTransport {
+
+	/**
+	 * Send mail
+	 *
+	 * @param \Cake\Mailer\Email $email Email
+	 * @return array
+	 */
+	public function send(Email $email) {
+		if (!empty($this->_config['queue'])) {
+			$this->_config = $this->_config['queue'] + $this->_config;
+			$email->config((array)$this->_config['queue'] + ['queue' => []]);
+			unset($this->_config['queue']);
+		}
+
+		$settings = [
+			'from' => [$email->from()],
+			'to' => [$email->to()],
+			'cc' => [$email->cc()],
+			'bcc' => [$email->bcc()],
+			'charset' => [$email->charset()],
+			'replyTo' => [$email->replyTo()],
+			'readReceipt' => [$email->readReceipt()],
+			'returnPath' => [$email->returnPath()],
+			'messageId' => [$email->messageId()],
+			'domain' => [$email->domain()],
+			'getHeaders' => [$email->getHeaders()],
+			'headerCharset' => [$email->headerCharset()],
+			'theme' => [$email->theme()],
+			'profile' => [$email->profile()],
+			'emailFormat' => [$email->emailFormat()],
+			'subject' => [$email->subject()],
+			'transport' => [$this->_config['transport']],
+			'attachments' => [$email->attachments()],
+			'template' => $email->template(), //template() gives 2 values - template and layout
+			'viewVars' => [$email->viewVars()]
+		];
+
+		$QueuedTasks = TableRegistry::get('Queue.QueuedTasks');
+		$result = $QueuedTasks->createJob('Email', ['settings' => $settings]);
+		$result['headers'] = '';
+		$result['message'] = '';
+		return $result;
+	}
+
+}

--- a/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Queue\Test\TestCase\Mailer\Transport;
+
+use Cake\Mailer\Email;
+use Cake\TestSuite\TestCase;
+use Queue\Mailer\Transport\SimpleQueueTransport;
+
+/**
+ * Test case
+ */
+class SimpleQueueTransportTest extends TestCase {
+
+	public $fixtures = [
+		'plugin.Queue.QueuedTasks',
+	];
+
+	protected $QueueTransport;
+
+	/**
+	 * Setup
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->QueueTransport = new SimpleQueueTransport();
+	}
+
+	/**
+	 * Test configuration
+	 *
+	 * @return void
+	 */
+	public function testConfig() {
+		$Email = new Email();
+		$Email->transport('queue');
+		$Email->config('default');
+
+		$res = $Email->transport()->config();
+		//debug($res);
+		//$this->assertTrue(isset($res['queue']));
+	}
+
+	/**
+	 * TestSend method
+	 *
+	 * @return void
+	 */
+	public function testSendWithEmail() {
+		$Email = new Email();
+		$Email->from('noreply@cakephp.org', 'CakePHP Test');
+		$Email->to('cake@cakephp.org', 'CakePHP');
+		$Email->cc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
+		$Email->bcc('phpnut@cakephp.org');
+		$Email->subject('Testing Message');
+		$Email->transport('queue');
+		$config = $Email->config('default');
+		$this->QueueTransport->config($config);
+
+		$result = $this->QueueTransport->send($Email);
+		$this->assertEquals('Email', $result['jobtype']);
+		$this->assertTrue(strlen($result['data']) < 10000);
+
+		$output = unserialize($result['data']);
+		//debug($output);
+		//$this->assertEquals($Email, $output['settings']);
+	}
+
+}


### PR DESCRIPTION
SimpleQueueTranport extracts config from email to save space in db (for example with mails with attachments) and recreates them in email task