### PR TITLE
Increase data field size

### DIFF
--- a/config/Migrations/20161319000000_increase_data_size.php
+++ b/config/Migrations/20161319000000_increase_data_size.php
@@ -1,0 +1,24 @@
+
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class IncreaseDataSize extends AbstractMigration {
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     */
+    public function change() {
+        $table = $this->table('queued_tasks');
+
+        $table->changeColumn('data', 'text', [
+            'length' => 4294967295,
+            'null' => true,
+            'default' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
For LONGTEXT support. fixes #76 

Data field maximum size is increased from 64KiB to 4GiB