### PR TITLE
Symphosize improvements

### DIFF
--- a/Config/Migration/1453822680_adding_priority_field_to_queue_tasks.php
+++ b/Config/Migration/1453822680_adding_priority_field_to_queue_tasks.php
@@ -1,0 +1,60 @@
+<?php
+class AddingPriorityFieldToQueueTasks extends CakeMigration {
+
+/**
+ * Migration description
+ *
+ * @var string
+ */
+	public $description = 'adding_priority_field_to_queue_tasks';
+
+/**
+ * Actions to be performed
+ *
+ * @var array $migration
+ */
+	public $migration = array(
+		'up' => array(
+            'create_field' => [
+                'queued_tasks' => [
+                    'priority' => [
+                        'type' => 'integer',
+                        'null' => false,
+                        'default' => 5,
+						'length' => 4
+                    ],
+					'indexes' => array(
+						'priority' => array('column' => 'priority'),
+					),
+                ],
+            ]
+		),
+		'down' => array(
+            'drop_field' => [
+                'queued_tasks' => [
+                    'priority'
+                ],
+            ]
+		),
+	);
+
+/**
+ * Before migration callback
+ *
+ * @param string $direction Direction of migration process (up or down)
+ * @return bool Should process continue
+ */
+	public function before($direction) {
+		return true;
+	}
+
+/**
+ * After migration callback
+ *
+ * @param string $direction Direction of migration process (up or down)
+ * @return bool Should process continue
+ */
+	public function after($direction) {
+		return true;
+	}
+}

--- a/Model/CronTask.php
+++ b/Model/CronTask.php
@@ -132,6 +132,7 @@ class CronTask extends QueueAppModel {
 				'timediff(NOW(),notbefore) AS age'
 			],
 			'order' => [
+				'priority ASC',
 				'age DESC',
 				'id ASC'
 			],

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -11,6 +11,8 @@ App::uses('Hash', 'Utility');
  */
 class QueuedTask extends QueueAppModel {
 
+	public $_next_priority = 5;
+
 	public $rateHistory = [];
 
 	public $exit = false;
@@ -61,6 +63,12 @@ class QueuedTask extends QueueAppModel {
 		Configure::write('Queue', $conf);
 	}
 
+	public function nextPriority($priority)
+	{
+		$this->_next_priority = $priority;
+		return $this;
+	}
+
 /**
  * Add a new Job to the Queue.
  *
@@ -76,8 +84,10 @@ class QueuedTask extends QueueAppModel {
 			'jobtype' => $jobName,
 			'data' => serialize($data),
 			'group' => $group,
-			'reference' => $reference
+			'reference' => $reference,
+			'priority' => $this->_next_priority
 		];
+		$this->_next_priority = 5; // reset to default;
 		if ($notBefore !== null) {
 			$data['notbefore'] = date('Y-m-d H:i:s', strtotime($notBefore));
 		}
@@ -119,6 +129,7 @@ class QueuedTask extends QueueAppModel {
 				'age',
 			],
 			'order' => [
+				'priority ASC',
 				'age ASC',
 				'id ASC'
 			],
@@ -175,7 +186,7 @@ class QueuedTask extends QueueAppModel {
 		//debug($key);ob_flush();
 
 		// try to update one of the found tasks with the key of this worker.
-		$this->query('UPDATE ' . $this->tablePrefix . $this->table . ' SET workerkey = "' . $key . '", fetched = "' . date('Y-m-d H:i:s') . '" WHERE ' . implode(' OR ', $whereClause) . ' ORDER BY ' . $this->virtualFields['age'] . ' ASC, id ASC LIMIT 1');
+		$this->query('UPDATE ' . $this->tablePrefix . $this->table . ' SET workerkey = "' . $key . '", fetched = "' . date('Y-m-d H:i:s') . '" WHERE ' . implode(' OR ', $whereClause) . ' ORDER BY priority ASC, ' . $this->virtualFields['age'] . ' ASC, id ASC LIMIT 1');
 
 		// Read which one actually got updated, which is the job we are supposed to execute.
 		$data = $this->find('first', [


### PR DESCRIPTION
This includes our changes to the Queue plugin.  There are two main changes included with this pull request.
1. We added the concept of priority to queued tasks.  By default all tasks will have a priority of 5.  But you can specify a lower number like 3 and this will place the task in front of those with 5.

`$this->QueuedTask->nextPriority(2)->createJob('YourSuperCoolTask', [
'some_id' => '12345',
]);`
1. We have had cases where a task that is working with a remote api fails because of exceptions raised when the API is down.  We should be catching these exceptions in the task and handle failure there.  But this is a fail safe.  We added a try catch block that will log any exception making it up to the runworker method. then mark the task as failed and move on with out causing the worker to die.

I am open to suggestion on how we can make this a useful contribution to the plugin.  Any feedback is welcome.
