### PR TITLE
Set completed time in the same way other timestamps are set.

### DIFF
--- a/src/Model/Table/QueuedTasksTable.php
+++ b/src/Model/Table/QueuedTasksTable.php
@@ -309,7 +309,7 @@ class QueuedTasksTable extends Table {
 	 */
 	public function markJobDone($id) {
 		$fields = [
-			'completed' => time(),
+			'completed' => date('Y-m-d H:i:s'),
 		];
 		$conditions = [
 			'id' => $id,


### PR DESCRIPTION
I came across a situation where the created & fetched times were a timezone offset's distance apart from the completed time.  Using date('Y-m-d H:i:s') instead of time() matches completed time up with how created and fetched are set. (And fixed the offset issue)