### PR TITLE
Fix unlink warn when pid file does not exist

### DIFF
--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -248,7 +248,7 @@ class QueueShell extends Shell {
 				$this->hr();
 			}
 		}
-		if (!empty($pidFilePath)) {
+		if (file_exists($pidFilePath . 'queue_' . $pid . '.pid')) {
 			unlink($pidFilePath . 'queue_' . $pid . '.pid');
 		}
 	}


### PR DESCRIPTION
This is to avoid notice when ``$pidFilePath`` is not empy but ``$pidFilePath . 'queue_' . $pid . '.pid'`` does not exist.