### PR TITLE
add checks to empty values

### DIFF
--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -49,6 +49,12 @@ class SimpleQueueTransport extends AbstractTransport {
 			'template' => $email->template(), //template() gives 2 values - template and layout
 			'viewVars' => [$email->viewVars()]
 		];
+		
+		foreach ($settings as $setting => $value) {
+			if (empty($value) || array_key_exists(0, $value) && empty($value[0])) {
+				unset($settings[$setting]);
+			}
+		}
 
 		$QueuedTasks = TableRegistry::get('Queue.QueuedTasks');
 		$result = $QueuedTasks->createJob('Email', ['settings' => $settings]);

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -51,7 +51,7 @@ class SimpleQueueTransport extends AbstractTransport {
 		];
 		
 		foreach ($settings as $setting => $value) {
-			if (empty($value) || array_key_exists(0, $value) && empty($value[0])) {
+			if (array_key_exists(0, $value) && ($value[0] === null || $value[0] === [])) {
 				unset($settings[$setting]);
 			}
 		}

--- a/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
@@ -54,23 +54,70 @@ class SimpleQueueTransportTest extends TestCase {
 	 * @return void
 	 */
 	public function testSendWithEmail() {
-		$Email = new Email();
+		$config = [
+			'transport' => 'queue',
+			'charset' => 'utf-8',
+			'headerCharset' => 'utf-8',
+		];
+
+		$this->QueueTransport->config($config);
+		$Email = new Email($config);
+
 		$Email->from('noreply@cakephp.org', 'CakePHP Test');
 		$Email->to('cake@cakephp.org', 'CakePHP');
 		$Email->cc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
 		$Email->bcc('phpnut@cakephp.org');
 		$Email->subject('Testing Message');
-		$Email->transport('queue');
-		$config = $Email->config('default');
-		$this->QueueTransport->config($config);
+		$Email->attachments(['wow.txt' => [
+			'data' => 'much wow!',
+			'mimetype' => 'text/plain',
+			'contentId' => 'important'
+		]]);
+
+		$Email->template('test_template', 'test_layout');
+		$Email->subject('Testing Message');
+		$Email->replyTo('noreply@cakephp.org');
+		$Email->readReceipt('noreply2@cakephp.org');
+		$Email->returnPath('noreply3@cakephp.org');
+		$Email->domain('cakephp.org');
+		$Email->theme('EuroTheme');
+		$Email->emailFormat('both');
+		$Email->set('var1', 1);
+		$Email->set('var2', 2);
 
 		$result = $this->QueueTransport->send($Email);
 		$this->assertEquals('Email', $result['jobtype']);
 		$this->assertTrue(strlen($result['data']) < 10000);
 
 		$output = unserialize($result['data']);
+		$emailReconstructed = new Email($config);
+
+		foreach ($output['settings'] as $method => $setting) {
+			call_user_func_array([$emailReconstructed, $method], (array)$setting);
+		}
+
+		$this->assertEquals($emailReconstructed->from(), $Email->from());
+		$this->assertEquals($emailReconstructed->to(), $Email->to());
+		$this->assertEquals($emailReconstructed->cc(), $Email->cc());
+		$this->assertEquals($emailReconstructed->bcc(), $Email->bcc());
+		$this->assertEquals($emailReconstructed->subject(), $Email->subject());
+		$this->assertEquals($emailReconstructed->charset(), $Email->charset());
+		$this->assertEquals($emailReconstructed->headerCharset(), $Email->headerCharset());
+		$this->assertEquals($emailReconstructed->emailFormat(), $Email->emailFormat());
+		$this->assertEquals($emailReconstructed->replyTo(), $Email->replyTo());
+		$this->assertEquals($emailReconstructed->readReceipt(), $Email->readReceipt());
+		$this->assertEquals($emailReconstructed->returnPath(), $Email->returnPath());
+		$this->assertEquals($emailReconstructed->messageId(), $Email->messageId());
+		$this->assertEquals($emailReconstructed->domain(), $Email->domain());
+		$this->assertEquals($emailReconstructed->theme(), $Email->theme());
+		$this->assertEquals($emailReconstructed->profile(), $Email->profile());
+		$this->assertEquals($emailReconstructed->viewVars(),$Email->viewVars());
+		$this->assertEquals($emailReconstructed->template(),$Email->template());
+		
+		//for now cannot be done 'data' is base64_encode on set but not decoded when get from $email
+		//$this->assertEquals($emailReconstructed->attachments(),$Email->attachments());
+
 		//debug($output);
 		//$this->assertEquals($Email, $output['settings']);
 	}
-
 }


### PR DESCRIPTION
when some of the values are null when recreating email it throws invalid argument exception so to bypass it just unset email settings that are empty