### PR TITLE
Fix query when MySql configured with sql_mode=only_full_group_by

### DIFF
--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -276,8 +276,14 @@ class QueuedTask extends QueueAppModel {
  * @return array
  */
 	public function getTypes() {
+		/*
+		 * 'jobtype' is intentionally duplicated in the 'fields' array.
+		 * Otherwise Cake auto-adds 'id' to the field list
+		 * which breaks MySql configured with sql_mode=only_full_group_by
+		 */
 		$findCond = [
 			'fields' => [
+				'jobtype',
 				'jobtype'
 			],
 			'group' => [


### PR DESCRIPTION
Tiny tweak for the 2.x branch: the query in QueuedTasks->getTypes() does a "list" find with a single "fields" parameter and a single "group" parameter.
Cake automatically adds the primary key to the "fields" array, and the resulting query breaks MySql if it's configured with strict GROUP BY rules:
```sql
SELECT QueuedTask.id, QueuedTask.jobtype
FROM queued_tasks QueuedTask
GROUP BY QueuedTask.jobtype
```
```
SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'QueuedTask.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

Adding a second copy of "jobtype" to the "fields" parameter fixes the issue, and Cake is smart enough to build the actual query without the duplicate:
```sql
SELECT QueuedTask.jobtype
FROM queued_tasks QueuedTask
GROUP BY QueuedTask.jobtype
```
