### PR TITLE
2.x switch to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .svn
 *.bak
+.DS_Store

--- a/Console/Command/CronShell.php
+++ b/Console/Command/CronShell.php
@@ -174,7 +174,7 @@ class CronShell extends AppShell {
 				if ($data) {
 					$this->out('Running Job of type "' . $data['jobtype'] . '"');
 					$taskname = 'queue_' . strtolower($data['jobtype']);
-					$return = $this->{$taskname}->run(stripslashes(unserialize($data['data'])));
+					$return = $this->{$taskname}->run(json_decode($data['data'], true));
 					if ($return == true) {
 						$this->CronTask->markJobDone($data['id']);
 						$this->out('Job Finished.');

--- a/Console/Command/CronShell.php
+++ b/Console/Command/CronShell.php
@@ -174,7 +174,7 @@ class CronShell extends AppShell {
 				if ($data) {
 					$this->out('Running Job of type "' . $data['jobtype'] . '"');
 					$taskname = 'queue_' . strtolower($data['jobtype']);
-					$return = $this->{$taskname}->run(unserialize($data['data']));
+					$return = $this->{$taskname}->run(stripslashes(unserialize($data['data'])));
 					if ($return == true) {
 						$this->CronTask->markJobDone($data['id']);
 						$this->out('Job Finished.');
@@ -272,4 +272,3 @@ class CronShell extends AppShell {
 		return $this->_taskConf;
 	}
 }
-

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -211,7 +211,7 @@ class QueueShell extends AppShell {
 					$taskname = 'Queue' . $data['jobtype'];
 
 					if ($this->{$taskname}->autoUnserialize) {
-						$data['data'] = stripslashes(unserialize($data['data']));
+						$data['data'] = json_decode($data['data'], true);
 					}
 					$return = $this->{$taskname}->run($data['data'], $data['id']);
 					if ($return) {

--- a/Console/Command/QueueShell.php
+++ b/Console/Command/QueueShell.php
@@ -211,7 +211,7 @@ class QueueShell extends AppShell {
 					$taskname = 'Queue' . $data['jobtype'];
 
 					if ($this->{$taskname}->autoUnserialize) {
-						$data['data'] = unserialize($data['data']);
+						$data['data'] = stripslashes(unserialize($data['data']));
 					}
 					$return = $this->{$taskname}->run($data['data'], $data['id']);
 					if ($return) {

--- a/Model/CronTask.php
+++ b/Model/CronTask.php
@@ -89,7 +89,7 @@ class CronTask extends QueueAppModel {
 	public function createJob($jobName, $data, $notBefore = null, $group = null, $reference = null) {
 		$data = [
 			'jobtype' => $jobName,
-			'data' => serialize($data),
+			'data' => serialize(addslashes($data)),
 			'group' => $group,
 			'reference' => $reference
 		];
@@ -369,4 +369,3 @@ class CronTask extends QueueAppModel {
 	const TYPE_MODEL = 1;
 
 }
-

--- a/Model/CronTask.php
+++ b/Model/CronTask.php
@@ -89,7 +89,7 @@ class CronTask extends QueueAppModel {
 	public function createJob($jobName, $data, $notBefore = null, $group = null, $reference = null) {
 		$data = [
 			'jobtype' => $jobName,
-			'data' => serialize(addslashes($data)),
+			'data' => json_encode($data),
 			'group' => $group,
 			'reference' => $reference
 		];

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -74,7 +74,7 @@ class QueuedTask extends QueueAppModel {
 	public function createJob($jobName, $data = null, $notBefore = null, $group = null, $reference = null) {
 		$data = [
 			'jobtype' => $jobName,
-			'data' => serialize($data),
+			'data' => serialize(addslashes($data)),
 			'group' => $group,
 			'reference' => $reference
 		];

--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -74,7 +74,7 @@ class QueuedTask extends QueueAppModel {
 	public function createJob($jobName, $data = null, $notBefore = null, $group = null, $reference = null) {
 		$data = [
 			'jobtype' => $jobName,
-			'data' => serialize(addslashes($data)),
+			'data' => json_encode($data),
 			'group' => $group,
 			'reference' => $reference
 		];

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> Forked to fix issues with serialized date.
+
+**Still having problems with data? Change your data field to 'LONGTEXT' - cake doesnt support this in it's schemafile but it will recognise it.**
+
+--
+
 # CakePHP Queue Plugin
 [![Build Status](https://api.travis-ci.org/dereuromark/cakephp-queue.svg?branch=2.x)](https://travis-ci.org/dereuromark/cakephp-queue)
 [![Minimum PHP Version](http://img.shields.io/badge/php-%3E%3D%205.4-8892BF.svg)](https://php.net/)
@@ -167,4 +173,3 @@ Added by Christian Charukiewicz ([charukiewicz](https://github.com/charukiewicz)
 - Fixed typo in README and variable name (Propability -> Probability)
 - Added a few lines about createJob() usage to README
 - Added comments to queue.php explaining configuration options
-

--- a/Test/Case/Model/QueuedTaskTest.php
+++ b/Test/Case/Model/QueuedTaskTest.php
@@ -111,7 +111,7 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->assertEquals('task1', $data['jobtype']);
 		$this->assertEquals(0, $data['failed']);
 		$this->assertNull($data['completed']);
-		$this->assertEquals($testData, unserialize($data['data']));
+		$this->assertEquals($testData, stripslashes(unserialize($data['data'])));
 
 		// after this job has been fetched, it may not be reassigned.
 		$result = $this->QueuedTask->requestJob($capabilities);
@@ -157,7 +157,7 @@ class QueuedTaskTest extends CakeTestCase {
 			$this->QueuedTask->clearKey();
 			$job = $this->QueuedTask->requestJob($capabilities);
 			//debug($job);ob_flush();
-			$jobData = unserialize($job['data']);
+			$jobData = stripslashes(unserialize($job['data']));
 			//debug($jobData);ob_flush();
 			$this->assertEquals($num, $jobData['tasknum']);
 		}
@@ -170,7 +170,7 @@ class QueuedTaskTest extends CakeTestCase {
 		// jobs should be fetched in the original sequence.
 		foreach (range(5, 9) as $num) {
 			$job = $this->QueuedTask->requestJob($capabilities);
-			$jobData = unserialize($job['data']);
+			$jobData = stripslashes(unserialize($job['data']));
 			$this->assertEquals($num, $jobData['tasknum']);
 			$this->assertTrue($this->QueuedTask->markJobDone($job['id']));
 			$this->assertEquals(9 - $num, $this->QueuedTask->getLength());
@@ -247,7 +247,7 @@ class QueuedTaskTest extends CakeTestCase {
 			$tmp = $this->QueuedTask->requestJob($capabilities);
 
 			$this->assertEquals($item['name'], $tmp['jobtype']);
-			$this->assertEquals($item['data'], unserialize($tmp['data']));
+			$this->assertEquals($item['data'], stripslashes(unserialize($tmp['data'])));
 		}
 	}
 
@@ -285,19 +285,19 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('task1', $tmp['jobtype']);
-		$this->assertEquals('1', unserialize($tmp['data']));
+		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
 
 		//The rate limit should now skip over task1-2 and fetch a dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('dummytask', $tmp['jobtype']);
-		$this->assertNull(unserialize($tmp['data']));
+		$this->assertNull(stripslashes(unserialize($tmp['data'])));
 
 		//and again.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('dummytask', $tmp['jobtype']);
-		$this->assertNull(unserialize($tmp['data']));
+		$this->assertNull(stripslashes(unserialize($tmp['data'])));
 
 		//Then some time passes
 		sleep(1);
@@ -306,13 +306,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('2', unserialize($tmp['data']));
+		$this->assertEquals('2', stripslashes(unserialize($tmp['data'])));
 
 		//and again rate limit to dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'dummytask');
-		$this->assertNull(unserialize($tmp['data']));
+		$this->assertNull(stripslashes(unserialize($tmp['data'])));
 
 		//Then some more time passes
 		sleep(1);
@@ -321,13 +321,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('3', unserialize($tmp['data']));
+		$this->assertEquals('3', stripslashes(unserialize($tmp['data'])));
 
 		//and again rate limit to dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'dummytask');
-		$this->assertNull(unserialize($tmp['data']));
+		$this->assertNull(stripslashes(unserialize($tmp['data'])));
 
 		//and now the queue is empty
 		$this->QueuedTask->clearKey();
@@ -355,14 +355,14 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', unserialize($tmp['data']));
+		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
 		$this->assertEquals($tmp['failed'], '0');
 		sleep(2);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', unserialize($tmp['data']));
+		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
 		$this->assertEquals($tmp['failed'], '1');
 		$this->assertEquals($tmp['failure_message'], 'Restart after timeout');
 	}
@@ -394,14 +394,14 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', unserialize($tmp['data']));
+		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
 		$this->assertEquals($tmp['failed'], '0');
 		sleep(2);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', unserialize($tmp['data']));
+		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
 		$this->assertEquals($tmp['failed'], '1');
 		$this->assertEquals($tmp['failure_message'], 'Restart after timeout');
 	}
@@ -425,13 +425,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(1, unserialize($tmp['data']));
+		$this->assertEquals(1, stripslashes(unserialize($tmp['data'])));
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
 
-		$this->assertEquals(2, unserialize($tmp['data']));
+		$this->assertEquals(2, stripslashes(unserialize($tmp['data'])));
 
 		// well, lets tra that Again, while limiting by Group
 		// create an ungrouped task
@@ -445,12 +445,12 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities, 'testgroup');
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(unserialize($tmp['data']), 4);
+		$this->assertEquals(stripslashes(unserialize($tmp['data'])), 4);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities, 'testgroup');
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(6, unserialize($tmp['data']));
+		$this->assertEquals(6, stripslashes(unserialize($tmp['data'])));
 
 		// use FindProgress on the testgroup:
 		$progress = $this->QueuedTask->find('progress', [

--- a/Test/Case/Model/QueuedTaskTest.php
+++ b/Test/Case/Model/QueuedTaskTest.php
@@ -111,7 +111,7 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->assertEquals('task1', $data['jobtype']);
 		$this->assertEquals(0, $data['failed']);
 		$this->assertNull($data['completed']);
-		$this->assertEquals($testData, stripslashes(unserialize($data['data'])));
+		$this->assertEquals($testData, json_decode($data['data'], true));
 
 		// after this job has been fetched, it may not be reassigned.
 		$result = $this->QueuedTask->requestJob($capabilities);
@@ -157,7 +157,7 @@ class QueuedTaskTest extends CakeTestCase {
 			$this->QueuedTask->clearKey();
 			$job = $this->QueuedTask->requestJob($capabilities);
 			//debug($job);ob_flush();
-			$jobData = stripslashes(unserialize($job['data']));
+			$jobData = json_decode($job['data'], true);
 			//debug($jobData);ob_flush();
 			$this->assertEquals($num, $jobData['tasknum']);
 		}
@@ -170,7 +170,7 @@ class QueuedTaskTest extends CakeTestCase {
 		// jobs should be fetched in the original sequence.
 		foreach (range(5, 9) as $num) {
 			$job = $this->QueuedTask->requestJob($capabilities);
-			$jobData = stripslashes(unserialize($job['data']));
+			$jobData = json_decode($job['data'], true);
 			$this->assertEquals($num, $jobData['tasknum']);
 			$this->assertTrue($this->QueuedTask->markJobDone($job['id']));
 			$this->assertEquals(9 - $num, $this->QueuedTask->getLength());
@@ -247,7 +247,7 @@ class QueuedTaskTest extends CakeTestCase {
 			$tmp = $this->QueuedTask->requestJob($capabilities);
 
 			$this->assertEquals($item['name'], $tmp['jobtype']);
-			$this->assertEquals($item['data'], stripslashes(unserialize($tmp['data'])));
+			$this->assertEquals($item['data'], json_decode($tmp['data'], true));
 		}
 	}
 
@@ -285,19 +285,19 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('task1', $tmp['jobtype']);
-		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('1', json_decode($tmp['data'], true));
 
 		//The rate limit should now skip over task1-2 and fetch a dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('dummytask', $tmp['jobtype']);
-		$this->assertNull(stripslashes(unserialize($tmp['data'])));
+		$this->assertNull(json_decode($tmp['data'], true));
 
 		//and again.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals('dummytask', $tmp['jobtype']);
-		$this->assertNull(stripslashes(unserialize($tmp['data'])));
+		$this->assertNull(json_decode($tmp['data'], true));
 
 		//Then some time passes
 		sleep(1);
@@ -306,13 +306,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('2', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('2', json_decode($tmp['data'], true));
 
 		//and again rate limit to dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'dummytask');
-		$this->assertNull(stripslashes(unserialize($tmp['data'])));
+		$this->assertNull(json_decode($tmp['data'], true));
 
 		//Then some more time passes
 		sleep(1);
@@ -321,13 +321,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('3', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('3', json_decode($tmp['data'], true));
 
 		//and again rate limit to dummytask.
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'dummytask');
-		$this->assertNull(stripslashes(unserialize($tmp['data'])));
+		$this->assertNull(json_decode($tmp['data'], true));
 
 		//and now the queue is empty
 		$this->QueuedTask->clearKey();
@@ -355,14 +355,14 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('1', json_decode($tmp['data'], true));
 		$this->assertEquals($tmp['failed'], '0');
 		sleep(2);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('1', json_decode($tmp['data'], true));
 		$this->assertEquals($tmp['failed'], '1');
 		$this->assertEquals($tmp['failure_message'], 'Restart after timeout');
 	}
@@ -394,14 +394,14 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('1', json_decode($tmp['data'], true));
 		$this->assertEquals($tmp['failed'], '0');
 		sleep(2);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals('1', stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals('1', json_decode($tmp['data'], true));
 		$this->assertEquals($tmp['failed'], '1');
 		$this->assertEquals($tmp['failure_message'], 'Restart after timeout');
 	}
@@ -425,13 +425,13 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(1, stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals(1, json_decode($tmp['data'], true));
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities);
 		$this->assertEquals($tmp['jobtype'], 'task1');
 
-		$this->assertEquals(2, stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals(2, json_decode($tmp['data'], true));
 
 		// well, lets tra that Again, while limiting by Group
 		// create an ungrouped task
@@ -445,12 +445,12 @@ class QueuedTaskTest extends CakeTestCase {
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities, 'testgroup');
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(stripslashes(unserialize($tmp['data'])), 4);
+		$this->assertEquals(json_decode($tmp['data'], true), 4);
 
 		$this->QueuedTask->clearKey();
 		$tmp = $this->QueuedTask->requestJob($capabilities, 'testgroup');
 		$this->assertEquals($tmp['jobtype'], 'task1');
-		$this->assertEquals(6, stripslashes(unserialize($tmp['data'])));
+		$this->assertEquals(6, json_decode($tmp['data'], true));
 
 		// use FindProgress on the testgroup:
 		$progress = $this->QueuedTask->find('progress', [

--- a/Test/Case/Network/Email/QueueTransportTest.php
+++ b/Test/Case/Network/Email/QueueTransportTest.php
@@ -51,7 +51,7 @@ class QueueTransportTest extends CakeTestCase {
 		$this->assertEquals('Email', $result['QueuedTask']['jobtype']);
 		$this->assertTrue(strlen($result['QueuedTask']['data']) < 10000);
 
-		$output = stripslashes(unserialize($result['QueuedTask']['data']));
+		$output = json_decode($result['QueuedTask']['data'], true);
 		debug($output);
 	}
 

--- a/Test/Case/Network/Email/QueueTransportTest.php
+++ b/Test/Case/Network/Email/QueueTransportTest.php
@@ -51,7 +51,7 @@ class QueueTransportTest extends CakeTestCase {
 		$this->assertEquals('Email', $result['QueuedTask']['jobtype']);
 		$this->assertTrue(strlen($result['QueuedTask']['data']) < 10000);
 
-		$output = unserialize($result['QueuedTask']['data']);
+		$output = stripslashes(unserialize($result['QueuedTask']['data']));
 		debug($output);
 	}
 


### PR DESCRIPTION
We've had recurring problems with data becoming corrupt and/or damaged. Initially we assumed it was the TEXT limit being hit, but what's actually a cause is that the data isn't being stored correctly.

php's serialize methods don't sanitize their data. So if you have for example html with double quotes, that'll break your serialized array. 

Initially the thought was to essentially run through the data to be serialized and addslashes. However this had it's own issues if you start going down into recursive arrays.

A simpler fix was to simply switch out to json_encode / json_decode as this is able to both retain data integrity, and doesn't suffer from the same sanitization issue as serialize.
