### PR TITLE
fix subject with UTF chars for simpleQueueTransport

### DIFF
--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -43,7 +43,7 @@ class SimpleQueueTransport extends AbstractTransport {
 			'theme' => [$email->theme()],
 			'profile' => [$email->profile()],
 			'emailFormat' => [$email->emailFormat()],
-			'subject' => [$email->subject()],
+			'subject' => [$email->getOriginalSubject()],
 			'transport' => [$this->_config['transport']],
 			'attachments' => [$email->attachments()],
 			'template' => $email->template(), //template() gives 2 values - template and layout

--- a/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
@@ -75,7 +75,7 @@ class SimpleQueueTransportTest extends TestCase {
 		]]);
 
 		$Email->template('test_template', 'test_layout');
-		$Email->subject('Testing Message');
+		$Email->subject("L'utilisateur n'a pas pu être enregistré");
 		$Email->replyTo('noreply@cakephp.org');
 		$Email->readReceipt('noreply2@cakephp.org');
 		$Email->returnPath('noreply3@cakephp.org');


### PR DESCRIPTION
Email->subject() returns encoded text, we want to get decoded text instead