### PR TITLE
Fixed typo in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -281,7 +281,7 @@ Then they would at least not run forever, and might pile up only if you start th
 
 #### Via tool
 You can kill workers from the backend or the command line.
-Make sure you have set up the workers with the same user (www-data usually) as the user that triesto kill them, or it will not work.
+Make sure you have set up the workers with the same user (www-data usually) as the user that tries to kill them, or it will not work.
 
 #### Manually
 Manually killing workers can be done using `kill -15 PID`. Replace PID with the PID number (e.g. `kill -15 21212`).


### PR DESCRIPTION
Just a little typo:
Line 284: "triesto" -> "tries to"