### PR TITLE
replace Configure::read() with readOrFail() where appropiate

### DIFF
--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -142,10 +142,10 @@ class QueueController extends AppController {
 	 * @return array Status array
 	 */
 	protected function _status() {
-		$timeout = Configure::read('Queue.defaultworkertimeout');
+		$timeout = Configure::readOrFail('Queue.defaultworkertimeout');
 		$thresholdTime = time() - $timeout;
 
-		$pidFilePath = Configure::read('Queue.pidfilepath');
+		$pidFilePath = Configure::readOrFail('Queue.pidfilepath');
 		if (!$pidFilePath) {
 			$this->loadModel('Queue.QueueProcesses');
 			$results = $this->QueueProcesses->find()->where(['modified >' => $thresholdTime])->orderDesc('modified')->hydrate(false)->all()->toArray();

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -59,7 +59,7 @@ class QueueProcessesTable extends Table {
 	 * @return \Cake\Orm\Query
 	 */
 	public function findActive() {
-		$timeout = Configure::read('Queue.defaultworkertimeout');
+		$timeout = Configure::readOrFail('Queue.defaultworkertimeout');
 		$thresholdTime = time() - $timeout;
 
 		$query = $this->find()->where(['modified > ' => $thresholdTime]);
@@ -105,7 +105,7 @@ class QueueProcessesTable extends Table {
 	 * @return void
 	 */
 	public function cleanKilledProcesses() {
-		$timeout = Configure::read('Queue.defaultworkertimeout');
+		$timeout = Configure::readOrFail('Queue.defaultworkertimeout');
 		$thresholdTime = time() - $timeout;
 
 		$this->deleteAll(['modified <' => time() - $thresholdTime]);

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -72,7 +72,7 @@ class QueuedJobsTable extends Table {
 
 		// Fallback to Plugin config which can be overwritten via local app config.
 		Configure::load('Queue.app_queue');
-		$defaultConf = (array)Configure::read('Queue');
+		$defaultConf = (array)Configure::readOrFail('Queue');
 
 		$conf = array_merge($defaultConf, $conf);
 
@@ -369,14 +369,14 @@ class QueuedJobsTable extends Table {
 	 */
 	public function cleanOldJobs() {
 		$this->deleteAll([
-			'completed <' => time() - Configure::read('Queue.cleanuptimeout'),
+			'completed <' => time() - Configure::readOrFail('Queue.cleanuptimeout'),
 		]);
 		$pidFilePath = Configure::read('Queue.pidfilepath');
 		if (!$pidFilePath) {
 			return;
 		}
 		// Remove all old pid files left over
-		$timeout = time() - 2 * Configure::read('Queue.cleanuptimeout');
+		$timeout = time() - 2 * Configure::readOrFail('Queue.cleanuptimeout');
 		$Iterator = new RegexIterator(
 			new RecursiveIteratorIterator(new RecursiveDirectoryIterator($pidFilePath)),
 			'/^.+\_.+\.(pid)$/i',

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -188,20 +188,20 @@ TEXT;
 					$this->_log('job ' . $queuedTask['job_type'] . ', id ' . $queuedTask['id'] . ' failed and requeued', $pid);
 					$this->out('Job did not finish, requeued.');
 				}
-			} elseif (Configure::read('Queue.exitwhennothingtodo')) {
+			} elseif (Configure::readOrFail('Queue.exitwhennothingtodo')) {
 				$this->out('nothing to do, exiting.');
 				$this->_exit = true;
 			} else {
 				$this->out('nothing to do, sleeping.');
-				sleep(Configure::read('Queue.sleeptime'));
+				sleep(Configure::readOrFail('Queue.sleeptime'));
 			}
 
 			// check if we are over the maximum runtime and end processing if so.
-			if (Configure::read('Queue.workermaxruntime') && (time() - $starttime) >= Configure::read('Queue.workermaxruntime')) {
+			if (Configure::readOrFail('Queue.workermaxruntime') && (time() - $starttime) >= Configure::readOrFail('Queue.workermaxruntime')) {
 				$this->_exit = true;
-				$this->out('Reached runtime of ' . (time() - $starttime) . ' Seconds (Max ' . Configure::read('Queue.workermaxruntime') . '), terminating.');
+				$this->out('Reached runtime of ' . (time() - $starttime) . ' Seconds (Max ' . Configure::readOrFail('Queue.workermaxruntime') . '), terminating.');
 			}
-			if ($this->_exit || rand(0, 100) > (100 - Configure::read('Queue.gcprob'))) {
+			if ($this->_exit || rand(0, 100) > (100 - Configure::readOrFail('Queue.gcprob'))) {
 				$this->out('Performing Old job cleanup.');
 				$this->QueuedJobs->cleanOldJobs();
 			}
@@ -229,7 +229,7 @@ TEXT;
 	 * @return void
 	 */
 	public function clean() {
-		$this->out('Deleting old jobs, that have finished before ' . date('Y-m-d H:i:s', time() - Configure::read('Queue.cleanuptimeout')));
+		$this->out('Deleting old jobs, that have finished before ' . date('Y-m-d H:i:s', time() - Configure::readOrFail('Queue.cleanuptimeout')));
 		$this->QueuedJobs->cleanOldJobs();
 		$this->QueueProcesses->cleanKilledProcesses();
 	}
@@ -283,7 +283,7 @@ TEXT;
 	 */
 	public function settings() {
 		$this->out('Current Settings:');
-		$conf = (array)Configure::read('Queue');
+		$conf = (array)Configure::readOrFail('Queue');
 		foreach ($conf as $key => $val) {
 			if ($val === false) {
 				$val = 'no';
@@ -429,7 +429,7 @@ TEXT;
 	 * @return void
 	 */
 	protected function _log($type, $pid = null) {
-		if (!Configure::read('Queue.log')) {
+		if (!Configure::readOrFail('Queue.log')) {
 			return;
 		}
 
@@ -453,12 +453,12 @@ TEXT;
 				if (property_exists($this->{$taskName}, 'timeout')) {
 					$this->_taskConf[$taskName]['timeout'] = $this->{$taskName}->timeout;
 				} else {
-					$this->_taskConf[$taskName]['timeout'] = Configure::read('Queue.defaultworkertimeout');
+					$this->_taskConf[$taskName]['timeout'] = Configure::readOrFail('Queue.defaultworkertimeout');
 				}
 				if (property_exists($this->{$taskName}, 'retries')) {
 					$this->_taskConf[$taskName]['retries'] = $this->{$taskName}->retries;
 				} else {
-					$this->_taskConf[$taskName]['retries'] = Configure::read('Queue.defaultworkerretries');
+					$this->_taskConf[$taskName]['retries'] = Configure::readOrFail('Queue.defaultworkerretries');
 				}
 				if (property_exists($this->{$taskName}, 'rate')) {
 					$this->_taskConf[$taskName]['rate'] = $this->{$taskName}->rate;

--- a/src/Template/Admin/Queue/index.ctp
+++ b/src/Template/Admin/Queue/index.ctp
@@ -72,7 +72,7 @@ if (empty($data)) {
 <h3>Settings</h3>
 <ul>
 <?php
-	$configurations = Configure::read('Queue');
+	$configurations = Configure::readOrFail('Queue');
 	foreach ($configurations as $key => $configuration) {
 		echo '<li>';
 		if (is_dir($configuration)) {

--- a/tests/test_app/src/Template/Error/error500.ctp
+++ b/tests/test_app/src/Template/Error/error500.ctp
@@ -2,7 +2,7 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
-if (Configure::read('debug')):
+if (Configure::readOrFail('debug')):
     $this->layout = 'dev_error';
 
     $this->assign('title', $message);


### PR DESCRIPTION
### Why
Make the plugin run more reliable. If values required to run are missing => Exception.

### Note
1. I did not replace it everywhere a few occurrences exist, mostly around mailerClass, the old pid setting, and the optional IdeHelper.
2.  Also note that I could not run unit tests. First of all it does not come with phpunit and/or make file as a vendor dependency which would be cool (see TwigView) and then my local SQLite seems to not work with the unit tests.
For me Unit tests crash with:
```PDOException: SQLSTATE[HY000]: General error: 1 no such function: UNIX_TIMESTAMP in cakephp-queue/vendor/cakephp/cakephp/src/Database/Driver/Sqlite.php:105```
Let's see what the test runners on GH say.