### PR TITLE
Report correct command via queue install

### DIFF
--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -340,7 +340,7 @@ TEXT;
 	 * @return void
 	 */
 	public function install() {
-		$this->out('Run `bin/cake Migrations migrate --plugin Queue`');
+		$this->out('Run `bin/cake migrations migrate -p Queue`');
 		$this->out('Set up cronjob, e.g. via `crontab -e -u www-data`');
 	}
 

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -340,7 +340,7 @@ TEXT;
 	 * @return void
 	 */
 	public function install() {
-		$this->out('Run `cake Migrations.migrate -p Queue`');
+		$this->out('Run `bin/cake Migrations migrate --plugin Queue`');
 		$this->out('Set up cronjob, e.g. via `crontab -e -u www-data`');
 	}
 


### PR DESCRIPTION
```
$ bin/cake Migrations.migrate -p Queue
Exception: Shell class for "Migrations.Migrate" could not be found. in [/var/www/cakephp/app/vendor/cakephp/cakephp/src/Console/ShellDispatcher.php, line 327]
```

The dot won't work for me (anymore, used to in 2.x AFAIR).