### PR TITLE
fix if posix is not enabled (e.g. Windows)

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -561,7 +561,7 @@ class QueuedJobsTable extends Table {
 		$processes = [];
 		foreach (glob($pidFilePath . 'queue_*.pid') as $filename) {
 			$time = filemtime($filename);
-			preg_match('/\bqueue_(\d+)\.pid$/', $filename, $matches);
+			preg_match('/\bqueue_([0-9a-z]+)\.pid$/', $filename, $matches);
 			$processes[$matches[1]] = $time;
 		}
 


### PR DESCRIPTION
If posix is not enabled the filename is created as sha1 hash:

```php
Queue\Shell\QueueShell
	/**
	 * @return string
	 */
	protected function _retrievePid() {
		if (function_exists('posix_getpid')) {
			$pid = (string)posix_getpid();
		} else {
			$pid = $this->QueuedJobs->key();
		}

		return $pid;
	}
```
and `$pid = $this->QueuedJobs->key();` is set as
```php
	/**
	 * Generates a unique Identifier for the current worker thread.
	 *
	 * Useful to identify the currently running processes for this thread.
	 *
	 * @return string Identifier
	 */
	public function key() {
		if ($this->_key !== null) {
			return $this->_key;
		}
		$this->_key = sha1(microtime());
		return $this->_key;
	}
```