### PR TITLE
Fix to follow email transport defined in app.php

### DIFF
--- a/src/Shell/Task/QueueEmailTask.php
+++ b/src/Shell/Task/QueueEmailTask.php
@@ -72,7 +72,7 @@ class QueueEmailTask extends QueueTask {
 			$this->err('Queue Email task called without settings data.');
 			return false;
 		}
-		
+
 		if (!isset($data['transport'])) {
 			$this->err('Queue Email task needs a transport to be set to actually send the email.');
 			return false;

--- a/src/Shell/Task/QueueEmailTask.php
+++ b/src/Shell/Task/QueueEmailTask.php
@@ -78,7 +78,7 @@ class QueueEmailTask extends QueueTask {
 		if (is_object($email) && $email instanceof Email) {
 			try {
 				$transportClassNames = $email->configuredTransport();
-				$result = $email->transport($transportClassNames[0])->send();
+				$result = $email->setTransport($data['transport'])->send();
 
 				if (!isset($config['log']) || !empty($config['logTrace']) && $config['logTrace'] === true) {
 					$config['log'] = 'email_trace';

--- a/src/Shell/Task/QueueEmailTask.php
+++ b/src/Shell/Task/QueueEmailTask.php
@@ -72,12 +72,16 @@ class QueueEmailTask extends QueueTask {
 			$this->err('Queue Email task called without settings data.');
 			return false;
 		}
+		
+		if (!isset($data['transport'])) {
+			$this->err('Queue Email task needs a transport to be set to actually send the email.');
+			return false;
+		}
 
 		/** @var \Cake\Mailer\Email $email */
 		$email = $data['settings'];
 		if (is_object($email) && $email instanceof Email) {
 			try {
-				$transportClassNames = $email->configuredTransport();
 				$result = $email->setTransport($data['transport'])->send();
 
 				if (!isset($config['log']) || !empty($config['logTrace']) && $config['logTrace'] === true) {


### PR DESCRIPTION
PR to fix issue #169 

By default the `transport` property of the non-queue transport email config was not used, but the first one (default) 
This is fixed by using the `transport` property of the available `$data` containing the config of the email transport