### PR TITLE
Fixing warning on backoffice when runworker is running

### DIFF
--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -49,6 +49,7 @@ class QueueController extends AppController {
 
 		$this->set(compact('current', 'data', 'pendingDetails', 'status', 'tasks'));
 		$this->helpers[] = 'Tools.Format';
+		$this->helpers[] = 'Tools.Time';
 	}
 
 	/**


### PR DESCRIPTION
Warning (512): Method Cake\View\Helper\TimeHelper::relLengthOfTime does not exist [CORE\src\View\Helper.php, line 139]