### PR TITLE
PHP timeout fix.

### DIFF
--- a/config/app_queue.php
+++ b/config/app_queue.php
@@ -22,6 +22,9 @@ return [
 		// seconds of running time after which the worker will terminate (0 = unlimited)
 		'workermaxruntime' => 120,
 
+		// seconds of running time after which the PHP process will terminate, null uses workermaxruntime * 100
+		'workertimeout' => null,
+
 		// minimum time (in seconds) which a task remains in the database before being cleaned up.
 		'cleanuptimeout' => 3600,
 

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -145,8 +145,7 @@ TEXT;
 		$types = $this->_stringToArray($this->param('type'));
 
 		while (!$this->_exit) {
-			// make sure accidental overriding isnt possible
-			set_time_limit(0);
+			$this->_setPhpTimeout();
 
 			try {
 				$this->_updatePid($pid);
@@ -631,6 +630,21 @@ TEXT;
 		$array = Text::tokenize($param);
 
 		return array_filter($array);
+	}
+
+	/**
+	 * Makes sure accidental overriding isn't possible, uses workermaxruntime times 100 by default.
+	 *
+	 * @return void
+	 */
+	protected function _setPhpTimeout()
+	{
+		$timeLimit = (int)Configure::read('Queue.workermaxruntime') * 100;
+		if (Configure::read('Queue.workertimeout') !== null) {
+			$timeLimit = (int)Configure::read('Queue.workertimeout');
+		}
+
+		set_time_limit($timeLimit);
 	}
 
 }


### PR DESCRIPTION
Make sure that if a process gets stuck, e.g. in some exec() forever running code, that the crontab doesnt built up too many never-ending workers running and then killing the server.

Default: 120s*100 = 3.3h

So if you spawn new runners every 5 minutes via crontab cronjob setting, you get a total process count of 40 as the worse case scenario.