### PR TITLE
CakePHP 3.6+ Compatibility

### DIFF
--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -72,9 +72,13 @@ class QueueController extends AppController {
 			throw new NotFoundException();
 		}
 
-		$this->QueuedJobs->createJob($job);
+		try {
+			$this->QueuedJobs->createJob($job);
 
-		$this->Flash->success('Job ' . $job . ' added');
+			$this->Flash->success('Job ' . $job . ' added');
+		} catch (\Exception $e) {
+			$this->Flash->success('Job ' . $job . ' error: ' . $e->getMessage());
+		}
 
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -29,10 +29,10 @@ class QueueTransport extends AbstractTransport {
 		}
 
 		$transport = $this->_config['transport'];
-		$email->transport($transport);
+		$email->setTransport($transport);
 
 		/** @var \Queue\Model\Table\QueuedJobsTable $QueuedJobs */
-		$QueuedJobs = TableRegistry::get('Queue.QueuedJobs');
+		$QueuedJobs = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
 		$result = $QueuedJobs->createJob('Email', ['transport' => $transport, 'settings' => $email]);
 		$result['headers'] = '';
 		$result['message'] = '';

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -28,26 +28,27 @@ class SimpleQueueTransport extends AbstractTransport {
 		}
 
 		$settings = [
-			'from' => [$email->from()],
-			'to' => [$email->to()],
-			'cc' => [$email->cc()],
-			'bcc' => [$email->bcc()],
-			'charset' => [$email->charset()],
-			'replyTo' => [$email->replyTo()],
-			'readReceipt' => [$email->readReceipt()],
-			'returnPath' => [$email->returnPath()],
-			'messageId' => [$email->messageId()],
-			'domain' => [$email->domain()],
-			'getHeaders' => [$email->getHeaders()],
-			'headerCharset' => [$email->headerCharset()],
-			'theme' => [$email->theme()],
-			'profile' => [$email->profile()],
-			'emailFormat' => [$email->emailFormat()],
-			'subject' => method_exists($email, 'getOriginalSubject') ? [$email->getOriginalSubject()] : [$email->subject()],
+			'from' => [$email->getFrom()],
+			'to' => [$email->getTo()],
+			'cc' => [$email->getCc()],
+			'bcc' => [$email->getBcc()],
+			'charset' => [$email->getCharset()],
+			'replyTo' => [$email->getReplyTo()],
+			'readReceipt' => [$email->getReadReceipt()],
+			'returnPath' => [$email->getReturnPath()],
+			'messageId' => [$email->getMessageId()],
+			'domain' => [$email->getDomain()],
+			'headers' => [$email->getHeaders()],
+			'headerCharset' => [$email->getHeaderCharset()],
+			'theme' => [$email->getTheme()],
+			'profile' => [$email->getProfile()],
+			'emailFormat' => [$email->getEmailFormat()],
+			'subject' => method_exists($email, 'getOriginalSubject') ? [$email->getOriginalSubject()] : [$email->getSubject()],
 			'transport' => [$this->_config['transport']],
-			'attachments' => [$email->attachments()],
-			'template' => $email->template(), //template() gives 2 values - template and layout
-			'viewVars' => [$email->viewVars()]
+			'attachments' => [$email->getAttachments()],
+			'template' => [$email->getTemplate()],
+			'layout' => [$email->getLayout()],
+			'viewVars' => [$email->getViewVars()]
 		];
 
 		foreach ($settings as $setting => $value) {

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -573,7 +573,7 @@ class QueuedJobsTable extends Table {
 	 * @return void
 	 */
 	public function clearDoublettes() {
-		$x = $this->_connection->query('SELECT max(id) as id FROM `' . $this->table() . '`
+		$x = $this->_connection->query('SELECT max(id) as id FROM `' . $this->getTable() . '`
 	WHERE completed is NULL
 	GROUP BY data
 	HAVING COUNT(id) > 1');
@@ -619,7 +619,7 @@ class QueuedJobsTable extends Table {
 	 * @return void
 	 */
 	public function truncate() {
-		$sql = $this->schema()->truncateSql($this->_connection);
+		$sql = $this->getSchema()->truncateSql($this->_connection);
 		foreach ($sql as $snippet) {
 			$this->_connection->execute($snippet);
 		}
@@ -632,8 +632,8 @@ class QueuedJobsTable extends Table {
 		$pidFilePath = Configure::read('Queue.pidfilepath');
 		if (!$pidFilePath) {
 			/** @var \Queue\Model\Table\QueueProcessesTable $QueueProcesses */
-			$QueueProcesses = TableRegistry::get('Queue.QueueProcesses');
-			$processes = $QueueProcesses->findActive()->hydrate(false)->find('list', ['keyField' => 'pid', 'valueField' => 'modified'])->all()->toArray();
+			$QueueProcesses = TableRegistry::getTableLocator()->get('Queue.QueueProcesses');
+			$processes = $QueueProcesses->findActive()->enableHydration(false)->find('list', ['keyField' => 'pid', 'valueField' => 'modified'])->all()->toArray();
 
 			return $processes;
 		}

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -10,7 +10,6 @@ use Cake\I18n\Time;
 use Cake\Log\Log;
 use Cake\Utility\Inflector;
 use Cake\Utility\Text;
-use Exception;
 use Queue\Queue\TaskFinder;
 use Throwable;
 

--- a/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
@@ -36,28 +36,29 @@ class SimpleQueueTransportTest extends TestCase {
 			'headerCharset' => 'utf-8',
 		];
 
-		$this->QueueTransport->config($config);
+		$this->QueueTransport->setConfig($config);
 		$Email = new Email($config);
 
-		$Email->from('noreply@cakephp.org', 'CakePHP Test');
-		$Email->to('cake@cakephp.org', 'CakePHP');
-		$Email->cc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
-		$Email->bcc('phpnut@cakephp.org');
-		$Email->subject('Testing Message');
-		$Email->attachments(['wow.txt' => [
+		$Email->setFrom('noreply@cakephp.org', 'CakePHP Test');
+		$Email->setTo('cake@cakephp.org', 'CakePHP');
+		$Email->setCc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
+		$Email->setBcc('phpnut@cakephp.org');
+		$Email->setSubject('Testing Message');
+		$Email->setAttachments(['wow.txt' => [
 			'data' => 'much wow!',
 			'mimetype' => 'text/plain',
 			'contentId' => 'important'
 		]]);
 
-		$Email->template('test_template', 'test_layout');
-		$Email->subject("L'utilisateur n'a pas pu être enregistré");
-		$Email->replyTo('noreply@cakephp.org');
-		$Email->readReceipt('noreply2@cakephp.org');
-		$Email->returnPath('noreply3@cakephp.org');
-		$Email->domain('cakephp.org');
-		$Email->theme('EuroTheme');
-		$Email->emailFormat('both');
+		$Email->setLayout('test_layout');
+		$Email->setTemplate('test_template');
+		$Email->setSubject("L'utilisateur n'a pas pu être enregistré");
+		$Email->setReplyTo('noreply@cakephp.org');
+		$Email->setReadReceipt('noreply2@cakephp.org');
+		$Email->setReturnPath('noreply3@cakephp.org');
+		$Email->setDomain('cakephp.org');
+		$Email->setTheme('EuroTheme');
+		$Email->setEmailFormat('both');
 		$Email->set('var1', 1);
 		$Email->set('var2', 2);
 
@@ -69,26 +70,28 @@ class SimpleQueueTransportTest extends TestCase {
 		$emailReconstructed = new Email($config);
 
 		foreach ($output['settings'] as $method => $setting) {
-			call_user_func_array([$emailReconstructed, $method], (array)$setting);
+			$setter = 'set' . ucfirst($method);
+			call_user_func_array([$emailReconstructed, $setter], (array)$setting);
 		}
 
-		$this->assertEquals($emailReconstructed->from(), $Email->from());
-		$this->assertEquals($emailReconstructed->to(), $Email->to());
-		$this->assertEquals($emailReconstructed->cc(), $Email->cc());
-		$this->assertEquals($emailReconstructed->bcc(), $Email->bcc());
-		$this->assertEquals($emailReconstructed->subject(), $Email->subject());
-		$this->assertEquals($emailReconstructed->charset(), $Email->charset());
-		$this->assertEquals($emailReconstructed->headerCharset(), $Email->headerCharset());
-		$this->assertEquals($emailReconstructed->emailFormat(), $Email->emailFormat());
-		$this->assertEquals($emailReconstructed->replyTo(), $Email->replyTo());
-		$this->assertEquals($emailReconstructed->readReceipt(), $Email->readReceipt());
-		$this->assertEquals($emailReconstructed->returnPath(), $Email->returnPath());
-		$this->assertEquals($emailReconstructed->messageId(), $Email->messageId());
-		$this->assertEquals($emailReconstructed->domain(), $Email->domain());
-		$this->assertEquals($emailReconstructed->theme(), $Email->theme());
-		$this->assertEquals($emailReconstructed->profile(), $Email->profile());
-		$this->assertEquals($emailReconstructed->viewVars(), $Email->viewVars());
-		$this->assertEquals($emailReconstructed->template(), $Email->template());
+		$this->assertEquals($emailReconstructed->getFrom(), $Email->getFrom());
+		$this->assertEquals($emailReconstructed->getTo(), $Email->getTo());
+		$this->assertEquals($emailReconstructed->getCc(), $Email->getCc());
+		$this->assertEquals($emailReconstructed->getBcc(), $Email->getBcc());
+		$this->assertEquals($emailReconstructed->getSubject(), $Email->getSubject());
+		$this->assertEquals($emailReconstructed->getCharset(), $Email->getCharset());
+		$this->assertEquals($emailReconstructed->getHeaderCharset(), $Email->getHeaderCharset());
+		$this->assertEquals($emailReconstructed->getEmailFormat(), $Email->getEmailFormat());
+		$this->assertEquals($emailReconstructed->getReplyTo(), $Email->getReplyTo());
+		$this->assertEquals($emailReconstructed->getReadReceipt(), $Email->getReadReceipt());
+		$this->assertEquals($emailReconstructed->getReturnPath(), $Email->getReturnPath());
+		$this->assertEquals($emailReconstructed->getMessageId(), $Email->getMessageId());
+		$this->assertEquals($emailReconstructed->getDomain(), $Email->getDomain());
+		$this->assertEquals($emailReconstructed->getTheme(), $Email->getTheme());
+		$this->assertEquals($emailReconstructed->getProfile(), $Email->getProfile());
+		$this->assertEquals($emailReconstructed->getViewVars(), $Email->getViewVars());
+		$this->assertEquals($emailReconstructed->getTemplate(), $Email->getTemplate());
+		$this->assertEquals($emailReconstructed->getLayout(), $Email->getLayout());
 
 		//for now cannot be done 'data' is base64_encode on set but not decoded when get from $email
 		//$this->assertEquals($emailReconstructed->attachments(),$Email->attachments());


### PR DESCRIPTION
Made some updates to enable compatibility with later cake versions.

- Admin/QueueController::addJob(): Uses exceptions to display Flash error
- Mailer/Transport/QueueTransport: transport() to setTransport() + getTableLocator()
- Mailer/Transport/SimpleQueueTransport:
   - All deprecated methods updated. eg to() -> setTo()
   - Added setLayout() instead of array passed to setTemplate()
- Model/Table/QueuedJobsTable: deprecated methods updated. eg schema -> getSchema()
- Shell/QueueShell:
   - Removed deprecated use of $task->failureMessage
   - Removed duplicate catch of Exception which is already caught by Throwable
 - Added markJobAsDone() 

All tests updated accordingly and passes OK.