### PR TITLE
Make migrations compatible with Phinx 0.10

### DIFF
--- a/config/Migrations/20150911132343_improvements_for_mysql.php
+++ b/config/Migrations/20150911132343_improvements_for_mysql.php
@@ -22,6 +22,8 @@ class ImprovementsForMysql extends AbstractMigration {
 			'null' => true,
 			'default' => null,
 		]);
+
+		$table->save();
 	}
 
 }

--- a/config/Migrations/20161319000000_increase_data_size.php
+++ b/config/Migrations/20161319000000_increase_data_size.php
@@ -27,6 +27,8 @@ class IncreaseDataSize extends AbstractMigration {
 					'null' => true,
 					'default' => null,
 				]);
+
+				$table->save();
 			}
 		} catch (Exception $e) {
 			Debugger::dump($e->getMessage());

--- a/config/Migrations/20171013131845_AlterQueuedJobs.php
+++ b/config/Migrations/20171013131845_AlterQueuedJobs.php
@@ -27,6 +27,8 @@ class AlterQueuedJobs extends AbstractMigration {
 					'null' => true,
 					'default' => null,
 				]);
+
+				$table->save();
 			}
 		} catch (Exception $e) {
 			Debugger::dump($e->getMessage());

--- a/config/Migrations/20171013133145_Utf8mb4Fix.php
+++ b/config/Migrations/20171013133145_Utf8mb4Fix.php
@@ -25,6 +25,7 @@ class Utf8mb4Fix extends AbstractMigration {
 			'encoding' => 'ascii',
 			'collation' => 'ascii_general_ci',
 		]);
+		$table->save();
 
 		$table = $this->table('queued_jobs');
 		$table->changeColumn('job_type', 'string', [
@@ -76,6 +77,7 @@ class Utf8mb4Fix extends AbstractMigration {
 			'encoding' => 'utf8mb4',
 			'collation' => 'utf8mb4_unicode_ci',
 		]);
+		$table->save();
 	}
 
 }

--- a/config/Migrations/20171019083500_ColumnLength.php
+++ b/config/Migrations/20171019083500_ColumnLength.php
@@ -22,6 +22,8 @@ class ColumnLength extends AbstractMigration {
 			'null' => false,
 			'default' => null,
 		]);
+
+		$table->save();
 	}
 
 }


### PR DESCRIPTION
Add required `save()` calls required on Phinx 0.10

I've tested on MySQL and results matches on both old and new Phinx:
- cakephp/migrations ^1.0 (1.8.1) + robmorgan/phinx (v0.8.1)
- cakephp/migrations ^2.0 (2.0.0) + robmorgan/phinx (0.10.6)