### PR TITLE
Defaults the kill input to 'all' so it can be run non-interactive

### DIFF
--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -260,7 +260,7 @@ TEXT;
 
 		$options = array_keys($processes);
 		$options[] = 'all';
-		$in = $this->in('Process', $options);
+		$in = $this->in('Process', $options, 'all');
 
 		if ($in === 'all') {
 			foreach ($processes as $process => $timestamp) {


### PR DESCRIPTION
We should just default the input to `all` so the command can be run non-interactive.

Fixes #199 