### PR TITLE
Use getmypid() instead of posix_getpid()

### DIFF
--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -603,9 +603,9 @@ TEXT;
 	 * @return string
 	 */
 	protected function _retrievePid() {
-		if (function_exists('posix_getpid')) {
-			$pid = (string)posix_getpid();
-		} else {
+		$pid = (string)getmypid();
+
+		if (!$pid) {
 			$pid = $this->QueuedJobs->key();
 		}
 


### PR DESCRIPTION
`getmypid()` is always available both on Windows and on Linux while `posix_getpid()` is not available on Windows.

`bin/cake queue end` failed with fallback  `sha1` pid.

With this PR, worker quits successfully on Windows.




