### PR TITLE
 Do not typecast PID to int

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -794,7 +794,7 @@ class QueuedJobsTable extends Table {
 	/**
 	 * Soft ending of a running job, e.g. when migration is starting
 	 *
-	 * @param int $pid
+	 * @param string $pid
 	 * @return void
 	 */
 	public function endProcess($pid) {

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -603,8 +603,9 @@ TEXT;
 	 * @return string
 	 */
 	protected function _retrievePid() {
-		$pid = (string)getmypid();
-		if (!$pid) {
+		if (function_exists('posix_getpid')) {
+			$pid = (string)posix_getpid();
+		} else {
 			$pid = $this->QueuedJobs->key();
 		}
 

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -289,7 +289,7 @@ TEXT;
 
 		if ($in === 'all' || $in === 'server') {
 			foreach ($processes as $process => $timestamp) {
-				$this->QueuedJobs->endProcess((int)$process);
+				$this->QueuedJobs->endProcess($process);
 			}
 
 			$this->out('All ' . count($processes) . ' processes ended.');
@@ -297,7 +297,7 @@ TEXT;
 			return;
 		}
 
-		$this->QueuedJobs->endProcess((int)$in);
+		$this->QueuedJobs->endProcess($in);
 	}
 
 	/**


### PR DESCRIPTION
 Do not typecast PID to int in `bin/cake queue end` as PID can be integer or sha1.

Ending workers failed because `58dfbdc23c1a8...` was typecasted to `58` and didn't match any process.

Also I'm reverting my previous PR #209 as some systems use hardcoded process IDs (#210).
