### PR TITLE
Add progress info and bars.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
 		"cakephp/cakephp": "^3.7"
 	},
 	"require-dev": {
-		"cakephp/migrations": "^1.0",
+		"cakephp/migrations": "^2.0",
 		"friendsofcake/search": "^5.0",
-		"dereuromark/cakephp-tools": "^1.9.1",
-		"dereuromark/cakephp-ide-helper": "^0.12",
+		"dereuromark/cakephp-tools": "^1.9.6",
+		"dereuromark/cakephp-ide-helper": "@stable",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},
 	"suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"cakephp/migrations": "^2.0",
 		"friendsofcake/search": "^5.0",
 		"dereuromark/cakephp-tools": "^1.9.6",
-		"dereuromark/cakephp-ide-helper": "@stable",
+		"dereuromark/cakephp-ide-helper": "^0.13.16",
 		"fig-r/psr2r-sniffer": "dev-master"
 	},
 	"suggest": {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+# Contributing
+
+I am looking forward to your contributions.
+
+There are a few guidelines that I need contributors to follow:
+* Coding standards (`composer cs-check` to check and `composer cs-fix` to fix)
+* PHPStan (`composer phpstan`, might need `composer phpstan-setup` first)
+* Passing tests (`php phpunit.phar`)
+
+
 ## Testing MySQL
 
 By default it will usually use SQLite DB (out of the box available).
@@ -13,3 +23,10 @@ php phpunit.phar
 ```
 
 Make sure such a `cake_test` database exists.
+
+## Updating Locale POT file
+
+Run this from your app dir to update the plugin's `queue.pot` file:
+```
+bin/cake i18n extract --plugin Queue --extract-core=no --merge=no --overwrite
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -360,11 +360,24 @@ Get progress status in web site and display:
 $job = $this->QueuedJobs->get($id);
 
 $progress = $job->progress; // A float from 0 to 1
-echo number_format($progress * 100, 0) . '%'; // Outputs 87% for example
+echo $this->Number->toPercentage($progress, 0, ['multiply' => true]) . '%'; // Outputs 87% for example
 
 $status = $job->status; // A string, make sure to escape
 echo h($status); // Outputs "Doing the last thing" for example
 ```
+
+#### Progress Bar
+Using Tools plugin 1.9.6+ you can also use the more visual progress bar (or any custom one of yours):
+```php
+echo $this->QueueProgress->progressBar($queuedJob, 18);
+```
+The length refers to the amount of chars to display.
+
+Make sure you loaded the helper in your AppView class.
+
+By default it first tries to use the actual `progress` stored as value 0...1.
+If that field is `null`, it tries to use the statistics of previously finished jobs of the same task
+to determine average length and displays the progress based on this.
 
 ### Logging
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -379,6 +379,15 @@ By default it first tries to use the actual `progress` stored as value 0...1.
 If that field is `null`, it tries to use the statistics of previously finished jobs of the same task
 to determine average length and displays the progress based on this.
 
+#### Timeout Progress Bar
+For those jobs that are created with a run time in the future (`notbefore`), you can also display progress
+until they are supposed to be run:
+
+```php
+echo $this->QueueProgress->timeoutProgressBar($queuedJob, 18);
+```
+It shows the progress as current time between `created` and `notbefore` boundaries more visually.
+
 ### Logging
 
 By default errors are always logged, and with log enabled also the execution of a job.

--- a/docs/README.md
+++ b/docs/README.md
@@ -777,9 +777,4 @@ It will not overwrite existing classes unless you explicitly force this (after p
 
 ## Contributing
 
-I am looking forward to your contributions.
-
-There are a few guidelines that I need contributors to follow:
-* Coding standards (`composer cs-check` to check and `composer cs-fix` to fix)
-* PHPStan (`composer phpstan`, might need `composer phpstan-setup` first)
-* Passing tests (`php phpunit.phar`)
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -31,11 +31,16 @@ class QueuedJobsController extends AppController {
 	public function initialize() {
 		parent::initialize();
 
-		$this->loadComponent('RequestHandler', [
-			'enableBeforeRedirect' => false,
-		]);
+		if (!$this->components()->has('RequestHandler')) {
+			$this->loadComponent('RequestHandler', [
+				'enableBeforeRedirect' => false,
+			]);
+		}
 
 		if (Configure::read('Queue.isSearchEnabled') === false || !Plugin::isLoaded('Search')) {
+			return;
+		}
+		if ($this->components()->has('Search')) {
 			return;
 		}
 		$this->loadComponent('Search.Prg', [

--- a/src/Locale/queue.pot
+++ b/src/Locale/queue.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-07-16 09:22+0000\n"
+"POT-Creation-Date: 2019-07-23 05:06+0000\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -14,63 +14,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: Controller/Admin/QueueController.php:144
-#: Controller/Admin/QueueController.php:160
+#: Controller/Admin/QueueController.php:143
+#: Controller/Admin/QueueController.php:158
 #: Shell/QueueShell.php:515
 msgid "OK"
 msgstr ""
 
-#: Controller/Admin/QueueProcessesController.php:71
+#: Controller/Admin/QueueProcessesController.php:69
 msgid "The queue process has been saved."
 msgstr ""
 
-#: Controller/Admin/QueueProcessesController.php:75
+#: Controller/Admin/QueueProcessesController.php:73
 msgid "The queue process could not be saved. Please, try again."
 msgstr ""
 
-#: Controller/Admin/QueueProcessesController.php:92
-#: Controller/Admin/QueueProcessesController.php:114
+#: Controller/Admin/QueueProcessesController.php:90
+#: Controller/Admin/QueueProcessesController.php:111
 msgid "The queue process has been deleted."
 msgstr ""
 
-#: Controller/Admin/QueueProcessesController.php:94
-#: Controller/Admin/QueueProcessesController.php:116
+#: Controller/Admin/QueueProcessesController.php:92
+#: Controller/Admin/QueueProcessesController.php:113
 msgid "The queue process could not be deleted. Please, try again."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:158
+#: Controller/Admin/QueuedJobsController.php:164
 msgid "Please, try again."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:174
+#: Controller/Admin/QueuedJobsController.php:179
 msgid "The queued job is already completed."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:181
+#: Controller/Admin/QueuedJobsController.php:186
 msgid "The queued job has been saved."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:185
+#: Controller/Admin/QueuedJobsController.php:190
 msgid "The queued job could not be saved. Please try again."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:210
+#: Controller/Admin/QueuedJobsController.php:214
 msgid "The queued job has been deleted."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:212
+#: Controller/Admin/QueuedJobsController.php:216
 msgid "The queued job could not be deleted. Please try again."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:239
+#: Controller/Admin/QueuedJobsController.php:243
 msgid "The requested job has been queued "
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:278
+#: Controller/Admin/QueuedJobsController.php:282
 msgid "The requested job has been queued."
 msgstr ""
 
-#: Controller/Admin/QueuedJobsController.php:283
+#: Controller/Admin/QueuedJobsController.php:287
 msgid "The job could not be queued. Please try again."
 msgstr ""
 
@@ -84,9 +84,9 @@ msgstr ""
 #: Template/Admin/QueuedJobs/execute.ctp:8
 #: Template/Admin/QueuedJobs/import.ctp:8
 #: Template/Admin/QueuedJobs/index.ctp:13
-#: Template/Admin/QueuedJobs/index.ctp:45
+#: Template/Admin/QueuedJobs/index.ctp:50
 #: Template/Admin/QueuedJobs/stats.ctp:14
-#: Template/Admin/QueuedJobs/test.ctp:9
+#: Template/Admin/QueuedJobs/test.ctp:10
 #: Template/Admin/QueuedJobs/view.ctp:9
 msgid "Actions"
 msgstr ""
@@ -101,10 +101,10 @@ msgstr ""
 #: Template/Admin/Queue/index.ctp:49
 #: Template/Admin/QueuedJobs/data.ctp:11
 #: Template/Admin/QueuedJobs/edit.ctp:18
-#: Template/Admin/QueuedJobs/execute.ctp:9
-#: Template/Admin/QueuedJobs/index.ctp:28
+#: Template/Admin/QueuedJobs/execute.ctp:10
+#: Template/Admin/QueuedJobs/index.ctp:35
 #: Template/Admin/QueuedJobs/stats.ctp:16
-#: Template/Admin/QueuedJobs/test.ctp:10
+#: Template/Admin/QueuedJobs/test.ctp:11
 #: Template/Admin/QueuedJobs/view.ctp:17
 msgid "Queued Jobs"
 msgstr ""
@@ -127,9 +127,9 @@ msgstr ""
 #: Template/Admin/QueueProcesses/view.ctp:19
 #: Template/Admin/QueuedJobs/data.ctp:11
 #: Template/Admin/QueuedJobs/edit.ctp:18
-#: Template/Admin/QueuedJobs/execute.ctp:9
+#: Template/Admin/QueuedJobs/execute.ctp:10
 #: Template/Admin/QueuedJobs/stats.ctp:16
-#: Template/Admin/QueuedJobs/test.ctp:10
+#: Template/Admin/QueuedJobs/test.ctp:11
 #: Template/Admin/QueuedJobs/view.ctp:17
 msgid "List {0}"
 msgstr ""
@@ -141,7 +141,7 @@ msgid "Queue"
 msgstr ""
 
 #: Template/Admin/Queue/index.ctp:29
-#: Template/Admin/QueuedJobs/view.ctp:76
+#: Template/Admin/QueuedJobs/view.ctp:75
 msgid "Status"
 msgstr ""
 
@@ -157,24 +157,72 @@ msgstr ""
 msgid "last {0}"
 msgstr ""
 
-#: Template/Admin/Queue/index.ctp:96
+#: Template/Admin/Queue/index.ctp:51
+msgid "{0} task(s) newly await processing."
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:61
+#: Template/Admin/QueuedJobs/view.ctp:92
+msgid "Soft reset"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:62
+#: Template/Admin/Queue/index.ctp:64
+msgid "Remove"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:69
+msgid "scheduled {0}"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:72
+#: Template/Admin/QueueProcesses/view.ctp:26
+#: Template/Admin/QueuedJobs/view.ctp:36
+msgid "Created"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:75
+#: Template/Admin/QueuedJobs/view.ctp:53
+msgid "Fetched"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:79
+msgid "status"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:83
+#: Template/Admin/QueuedJobs/view.ctp:79
+msgid "Progress"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:87
+msgid "Failures"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:89
+#: Template/Admin/QueuedJobs/view.ctp:123
+msgid "Failure Message"
+msgstr ""
+
+#: Template/Admin/Queue/index.ctp:99
 msgid "Statistics"
 msgstr ""
 
-#: Template/Admin/Queue/index.ctp:116
+#: Template/Admin/Queue/index.ctp:119
 msgid "Detailed Statistics"
 msgstr ""
 
-#: Template/Admin/Queue/index.ctp:167
+#: Template/Admin/Queue/index.ctp:170
 msgid "Trigger Delayed Test/Demo Job"
 msgstr ""
 
-#: Template/Admin/Queue/index.ctp:169
+#: Template/Admin/Queue/index.ctp:172
 msgid "Trigger Execute Job(s)"
 msgstr ""
 
 #: Template/Admin/Queue/processes.ctp:15
 #: Template/Admin/QueueProcesses/index.ctp:11
+#: Template/Admin/QueuedJobs/execute.ctp:9
 #: Template/Admin/QueuedJobs/index.ctp:14
 #: Template/Admin/QueuedJobs/stats.ctp:15
 #: Template/Admin/QueuedJobs/view.ctp:10
@@ -190,6 +238,30 @@ msgstr ""
 
 #: Template/Admin/Queue/processes.ctp:23
 msgid "Current Queue Processes"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:24
+msgid "Active processes"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:33
+msgid "Finish current job and end"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:35
+msgid "Kill"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:35
+msgid "Soft kill"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:48
+msgid "Terminated"
+msgstr ""
+
+#: Template/Admin/Queue/processes.ctp:49
+msgid "These have been marked as to be terminated after finishing this round"
 msgstr ""
 
 #: Template/Admin/QueueProcesses/edit.ctp:10
@@ -211,9 +283,9 @@ msgstr ""
 #: Template/Admin/QueueProcesses/edit.ctp:25
 #: Template/Admin/QueuedJobs/data.ctp:22
 #: Template/Admin/QueuedJobs/edit.ctp:30
-#: Template/Admin/QueuedJobs/execute.ctp:25
+#: Template/Admin/QueuedJobs/execute.ctp:26
 #: Template/Admin/QueuedJobs/import.ctp:23
-#: Template/Admin/QueuedJobs/test.ctp:27
+#: Template/Admin/QueuedJobs/test.ctp:28
 msgid "Submit"
 msgstr ""
 
@@ -234,12 +306,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: Template/Admin/QueueProcesses/index.ctp:50
+#: Template/Admin/QueueProcesses/index.ctp:58
 #: Template/Admin/QueueProcesses/view.ctp:14
 msgid "Terminate"
 msgstr ""
 
-#: Template/Admin/QueueProcesses/index.ctp:50
+#: Template/Admin/QueueProcesses/index.ctp:58
 #: Template/Admin/QueueProcesses/view.ctp:14
 msgid "Are you sure you want to terminate # {0}?"
 msgstr ""
@@ -259,14 +331,9 @@ msgstr ""
 
 #: Template/Admin/QueueProcesses/view.ctp:16
 #: Template/Admin/QueuedJobs/edit.ctp:14
-#: Template/Admin/QueuedJobs/index.ctp:75
+#: Template/Admin/QueuedJobs/index.ctp:108
 #: Template/Admin/QueuedJobs/view.ctp:16
 msgid "Are you sure you want to delete # {0}?"
-msgstr ""
-
-#: Template/Admin/QueueProcesses/view.ctp:26
-#: Template/Admin/QueuedJobs/view.ctp:36
-msgid "Created"
 msgstr ""
 
 #: Template/Admin/QueueProcesses/view.ctp:35
@@ -278,7 +345,7 @@ msgid "Server"
 msgstr ""
 
 #: Template/Admin/QueueProcesses/view.ctp:47
-#: Template/Admin/QueuedJobs/view.ctp:67
+#: Template/Admin/QueuedJobs/view.ctp:98
 msgid "Workerkey"
 msgstr ""
 
@@ -295,7 +362,7 @@ msgstr ""
 msgid "Edit Queued Job"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/execute.ctp:15
+#: Template/Admin/QueuedJobs/execute.ctp:16
 msgid "Trigger Execute Job"
 msgstr ""
 
@@ -307,11 +374,15 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
+#: Template/Admin/QueuedJobs/index.ctp:22
+msgid "Current server time"
+msgstr ""
+
 #: Template/Admin/QueuedJobs/stats.ctp:26
 msgid "Job Statistics"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/test.ctp:16
+#: Template/Admin/QueuedJobs/test.ctp:17
 msgid "Trigger Delayed Job"
 msgstr ""
 
@@ -339,31 +410,19 @@ msgstr ""
 msgid "Notbefore"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/view.ctp:44
-msgid "Fetched"
-msgstr ""
-
-#: Template/Admin/QueuedJobs/view.ctp:48
+#: Template/Admin/QueuedJobs/view.ctp:64
 msgid "Completed"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/view.ctp:52
-msgid "Progress"
-msgstr ""
-
-#: Template/Admin/QueuedJobs/view.ctp:56
+#: Template/Admin/QueuedJobs/view.ctp:87
 msgid "Failed"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/view.ctp:80
+#: Template/Admin/QueuedJobs/view.ctp:107
 msgid "Priority"
 msgstr ""
 
-#: Template/Admin/QueuedJobs/view.ctp:85
+#: Template/Admin/QueuedJobs/view.ctp:112
 msgid "Data"
-msgstr ""
-
-#: Template/Admin/QueuedJobs/view.ctp:96
-msgid "Failure Message"
 msgstr ""
 

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -29,7 +29,6 @@ declare(ticks = 1);
  *
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
- * @link http://github.com/MSeven/cakephp_queue
  * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
  * @property \Queue\Model\Table\QueueProcessesTable $QueueProcesses
  */

--- a/src/Shell/QueueShell.php
+++ b/src/Shell/QueueShell.php
@@ -292,41 +292,6 @@ TEXT;
 	}
 
 	/**
-	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 * @param string $pid
-	 * @return void
-	 */
-	protected function _runJob(QueuedJob $queuedJob, $pid) {
-		$this->out('Running Job of type "' . $queuedJob['job_type'] . '"');
-		$this->_log('job ' . $queuedJob['job_type'] . ', id ' . $queuedJob['id'], $pid);
-		$taskname = 'Queue' . $queuedJob['job_type'];
-
-		try {
-			$data = unserialize($queuedJob['data']);
-			/** @var \Queue\Shell\Task\QueueTask $task */
-			$task = $this->{$taskname};
-			if (!$task instanceof QueueTaskInterface) {
-				throw new RuntimeException('Task must implement ' . QueueTaskInterface::class);
-			}
-
-			$task->run((array)$data, $queuedJob['id']);
-
-		} catch (Exception $e) {
-			$failureMessage = get_class($e) . ': ' . $e->getMessage();
-			$this->_logError($taskname . "\n" . $failureMessage . "\n" . $e->getTraceAsString());
-
-			$this->QueuedJobs->markJobFailed($queuedJob, $failureMessage);
-			$failedStatus = $this->QueuedJobs->getFailedStatus($queuedJob, $this->_getTaskConf());
-			$this->_log('job ' . $queuedJob['job_type'] . ', id ' . $queuedJob['id'] . ' failed and ' . $failedStatus, $pid);
-			$this->out('Job did not finish, ' . $failedStatus . ' after try ' . $queuedJob->failed . '.');
-			return;
-		}
-
-		$this->QueuedJobs->markJobDone($queuedJob);
-		$this->out('Job Finished.');
-	}
-
-	/**
 	 * Manually trigger a Finished job cleanup.
 	 *
 	 * @return void

--- a/src/Shell/Task/QueueExampleTask.php
+++ b/src/Shell/Task/QueueExampleTask.php
@@ -2,7 +2,6 @@
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
- * @link http://github.com/MSeven/cakephp_queue
  */
 
 namespace Queue\Shell\Task;

--- a/src/Shell/Task/QueueExceptionExampleTask.php
+++ b/src/Shell/Task/QueueExceptionExampleTask.php
@@ -5,7 +5,7 @@ namespace Queue\Shell\Task;
 use Queue\Model\QueueException;
 
 /**
- * A Simple QueueTask example.
+ * An exception throwing QueueTask example.
  */
 class QueueExceptionExampleTask extends QueueTask implements AddInterface {
 

--- a/src/Shell/Task/QueueExecuteTask.php
+++ b/src/Shell/Task/QueueExecuteTask.php
@@ -2,7 +2,6 @@
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
- * @link http://github.com/MSeven/cakephp_queue
  */
 
 namespace Queue\Shell\Task;
@@ -25,10 +24,12 @@ class QueueExecuteTask extends QueueTask implements AddInterface {
 		$this->hr();
 		if (count($this->args) < 2) {
 			$this->out('This will run an shell command on the Server.');
-			$this->out('The task is mainly intended to serve as a kind of buffer for programm calls from a cakephp application.');
+			$this->out('The task is mainly intended to serve as a kind of buffer for programm calls from a CakePHP application.');
 			$this->out(' ');
 			$this->out('Call like this:');
-			$this->out('    cake queue add Execute *command* *param1* *param2* ...');
+			$this->out('    bin/cake queue add Execute *command* *param1* *param2* ...');
+			$this->out(' ');
+			$this->out('For commands with spaces use " around it. E.g. `bin/cake queue add Execute "sleep 10s"`.');
 			$this->out(' ');
 
 			return;

--- a/src/Shell/Task/QueueRetryExampleTask.php
+++ b/src/Shell/Task/QueueRetryExampleTask.php
@@ -2,7 +2,6 @@
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
- * @link http://github.com/MSeven/cakephp_queue
  */
 
 namespace Queue\Shell\Task;
@@ -10,7 +9,7 @@ namespace Queue\Shell\Task;
 use Cake\Console\ConsoleIo;
 
 /**
- * A Simple QueueTask example.
+ * A retry QueueTask example.
  */
 class QueueRetryExampleTask extends QueueTask implements AddInterface {
 

--- a/src/Shell/Task/QueueSuperExampleTask.php
+++ b/src/Shell/Task/QueueSuperExampleTask.php
@@ -2,13 +2,12 @@
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
- * @link http://github.com/MSeven/cakephp_queue
  */
 
 namespace Queue\Shell\Task;
 
 /**
- * A Simple QueueTask example.
+ * A cascading QueueTask example.
  */
 class QueueSuperExampleTask extends QueueTask implements AddInterface {
 
@@ -21,7 +20,7 @@ class QueueSuperExampleTask extends QueueTask implements AddInterface {
 
 	/**
 	 * SuperExample add functionality.
-	 * Will create one example job in the queue, which later will be executed using run();
+	 * Will create another example job in the queue, which later will be executed using run();
 	 *
 	 * To invoke from CLI execute:
 	 * - bin/cake queue add SuperExample
@@ -33,7 +32,7 @@ class QueueSuperExampleTask extends QueueTask implements AddInterface {
 		$this->hr();
 		$this->out('This is a very superb example of a QueueTask.');
 		$this->out('I will now add an example Job into the Queue.');
-		$this->out('It will also fire a callback upon successful execution.');
+		$this->out('It will also create another Example job upon successful execution.');
 		$this->out('This job will only produce some console output on the worker that it runs on.');
 		$this->out(' ');
 		$this->out('To run a Worker use:');

--- a/src/Template/Admin/Queue/index.ctp
+++ b/src/Template/Admin/Queue/index.ctp
@@ -20,7 +20,7 @@ use Cake\Core\Configure;
 	</ul>
 </nav>
 
-<div class="col-md-9 col-xs-12 large-9 medium-8 columns">
+<div class="content col-md-9 col-xs-12 large-9 medium-8 columns">
 <h1><?php echo __d('queue', 'Queue');?></h1>
 
 <div class="row">

--- a/src/Template/Admin/Queue/index.ctp
+++ b/src/Template/Admin/Queue/index.ctp
@@ -48,9 +48,7 @@ use Cake\Core\Configure;
 
 		<h2><?php echo __d('queue', 'Queued Jobs'); ?></h2>
 		<p>
-		<?php
-		echo $new . '/' .$current;
-		?> task(s) newly await processing.
+		<?php echo __d('queue', '{0} task(s) newly await processing.', $new . '/' . $current); ?>
 		</p>
 		<ol>
 			<?php
@@ -60,30 +58,36 @@ use Cake\Core\Configure;
 
 				$reset = '';
 				if ($pendingJob->failed) {
-					$reset = ' ' . $this->Form->postLink('Soft reset', ['action' => 'resetJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button primary btn margin btn-primary']);
-					$reset .= ' ' . $this->Form->postLink('Remove', ['action' => 'removeJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button secondary btn margin btn-default']);
+					$reset = ' ' . $this->Form->postLink(__d('queue', 'Soft reset'), ['action' => 'resetJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button primary btn margin btn-primary']);
+					$reset .= ' ' . $this->Form->postLink(__d('queue', 'Remove'), ['action' => 'removeJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button secondary btn margin btn-default']);
 				} elseif ($pendingJob->fetched) {
-					$reset .= ' ' . $this->Form->postLink('Remove', ['action' => 'removeJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button secondary btn margin btn-default']);
+					$reset .= ' ' . $this->Form->postLink(__d('queue', 'Remove'), ['action' => 'removeJob', $pendingJob->id], ['confirm' => 'Sure?', 'class' => 'button secondary btn margin btn-default']);
 				}
 
 				$notBefore = '';
 				if ($pendingJob->notbefore) {
-					$notBefore = ' (scheduled ' . $this->Time->nice($pendingJob->notbefore) . ')';
+					$notBefore = ' (' . __d('queue', 'scheduled {0}', $this->Time->nice($pendingJob->notbefore)) . ')';
 				}
 
-				echo '<li>Created: ' . $this->Time->nice($pendingJob->created) . $notBefore . '</li>';
+				echo '<li>' . __d('queue', 'Created') . ': ' . $this->Time->nice($pendingJob->created) . $notBefore . '</li>';
 
 				if ($pendingJob->fetched) {
-					echo '<li>Fetched: ' . $this->Time->nice($pendingJob->fetched) . '</li>';
+					echo '<li>' . __d('queue', 'Fetched') . ': ' . $this->Time->nice($pendingJob->fetched) . '</li>';
 
 					$status = '';
 					if ($pendingJob->status) {
-						$status = ' (status: ' . h($pendingJob->status) . ')';
+						$status = ' (' . __d('queue', 'status') . ': ' . h($pendingJob->status) . ')';
 					}
 
-					echo '<li>Progress: ' . $this->Number->toPercentage($pendingJob->progress * 100, 0) . $status . '</li>';
-					echo '<li>Failures: ' . $pendingJob->failed . $reset . '</li>';
-					echo '<li>Failure Message: ' . $this->Text->truncate($pendingJob->failure_message, 200) . '</li>';
+					echo '<li>';
+					echo __d('queue', 'Progress') . ': ';
+					echo $this->Number->toPercentage($pendingJob->progress, 0, ['multiply' => true]) . $status;
+					echo '<br>' . $this->QueueProgress->progressBar($pendingJob, 18);
+					echo '</li>';
+					echo '<li>' . __d('queue', 'Failures') . ': ' . $pendingJob->failed . $reset . '</li>';
+					if ($pendingJob->failure_message) {
+						echo '<li>' . __d('queue', 'Failure Message') . ': ' . $this->Text->truncate($pendingJob->failure_message, 200) . '</li>';
+					}
 				}
 
 				echo '</ul>';

--- a/src/Template/Admin/Queue/processes.ctp
+++ b/src/Template/Admin/Queue/processes.ctp
@@ -21,7 +21,7 @@ use Cake\I18n\Time;
 <h1><?php echo __d('queue', 'Queue');?></h1>
 
 <h2><?php echo __d('queue', 'Current Queue Processes'); ?></h2>
-	<p>Active processes:</p>
+	<p><?php echo __d('queue', 'Active processes'); ?>:</p>
 
 <ul>
 <?php
@@ -30,9 +30,9 @@ foreach ($processes as $process => $timestamp) {
 	echo '<ul>';
 	echo '<li>Last run: ' . $this->Time->nice(new Time($timestamp)) . '</li>';
 
-	echo '<li>End: ' . $this->Form->postLink('Finish current job and end', ['action' => 'processes', '?' => ['end' => $process]], ['confirm' => 'Sure?']) . ' (next loop run)</li>';
+	echo '<li>End: ' . $this->Form->postLink(__d('queue', 'Finish current job and end'), ['action' => 'processes', '?' => ['end' => $process]], ['confirm' => 'Sure?']) . ' (next loop run)</li>';
 	if (!$this->Configure->read('Queue.multiserver')) {
-		echo '<li>Kill: ' . $this->Form->postLink('Soft kill', ['action' => 'processes', '?' => ['kill' => $process]], ['confirm' => 'Sure?']) . ' (termination SIGTERM = 15)</li>';
+		echo '<li>' . __d('queue', 'Kill') . ': ' . $this->Form->postLink(__d('queue', 'Soft kill'), ['action' => 'processes', '?' => ['kill' => $process]], ['confirm' => 'Sure?']) . ' (termination SIGTERM = 15)</li>';
 	}
 
 	echo '</ul>';
@@ -45,8 +45,8 @@ if (empty($processes)) {
 </ul>
 
 <?php if (!empty($terminated)) { ?>
-	<h3>Terminated</h3>
-	<p>These have been marked as to be terminated after finishing this round:</p>
+	<h3><?php echo __d('queue', 'Terminated') ?></h3>
+	<p><?php echo __d('queue', 'These have been marked as to be terminated after finishing this round'); ?>:</p>
 	<ul>
 	<?php
 	foreach ($terminated as $queuedJob) {

--- a/src/Template/Admin/Queue/processes.ctp
+++ b/src/Template/Admin/Queue/processes.ctp
@@ -17,7 +17,7 @@ use Cake\I18n\Time;
 	</ul>
 </nav>
 
-<div class="col-md-9 col-xs-12 large-9 medium-8 columns">
+<div class="content col-md-9 col-xs-12 large-9 medium-8 columns">
 <h1><?php echo __d('queue', 'Queue');?></h1>
 
 <h2><?php echo __d('queue', 'Current Queue Processes'); ?></h2>
@@ -30,7 +30,7 @@ foreach ($processes as $process => $timestamp) {
 	echo '<ul>';
 	echo '<li>Last run: ' . $this->Time->nice(new Time($timestamp)) . '</li>';
 
-	echo '<li>End: ' . $this->Form->postLink(__d('queue', 'Finish current job and end'), ['action' => 'processes', '?' => ['end' => $process]], ['confirm' => 'Sure?']) . ' (next loop run)</li>';
+	echo '<li>End: ' . $this->Form->postLink(__d('queue', 'Finish current job and end'), ['action' => 'processes', '?' => ['end' => $process]], ['confirm' => 'Sure?', 'class' => 'button secondary btn margin btn-secondary']) . ' (next loop run)</li>';
 	if (!$this->Configure->read('Queue.multiserver')) {
 		echo '<li>' . __d('queue', 'Kill') . ': ' . $this->Form->postLink(__d('queue', 'Soft kill'), ['action' => 'processes', '?' => ['kill' => $process]], ['confirm' => 'Sure?']) . ' (termination SIGTERM = 15)</li>';
 	}

--- a/src/Template/Admin/QueueProcesses/edit.ctp
+++ b/src/Template/Admin/QueueProcesses/edit.ctp
@@ -13,7 +13,7 @@
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
 
-	<h3><?php echo __d('queue', 'Edit PID {0}', $queueProcess->pid); ?></h3>
+	<h1><?php echo __d('queue', 'Edit PID {0}', $queueProcess->pid); ?></h1>
 
 	<?= $this->Form->create($queueProcess) ?>
 	<fieldset>

--- a/src/Template/Admin/QueueProcesses/index.ctp
+++ b/src/Template/Admin/QueueProcesses/index.ctp
@@ -14,7 +14,7 @@ use Queue\Queue\Config;
 	</ul>
 </nav>
 <div class="content action-index index large-9 medium-8 columns col-sm-8 col-xs-12">
-	<h2><?= __d('queue', 'Queue Processes') ?></h2>
+	<h1><?= __d('queue', 'Queue Processes') ?></h1>
 	<table class="table table-striped">
 		<thead>
 			<tr>

--- a/src/Template/Admin/QueueProcesses/view.ctp
+++ b/src/Template/Admin/QueueProcesses/view.ctp
@@ -20,7 +20,7 @@ use Queue\Queue\Config;
 	</ul>
 </nav>
 <div class="content action-view view large-9 medium-8 columns col-sm-8 col-xs-12">
-	<h2>PID <?= h($queueProcess->pid) ?></h2>
+	<h1>PID <?= h($queueProcess->pid) ?></h1>
 	<table class="table vertical-table">
 		<tr>
 			<th><?= __d('queue', 'Created') ?></th>

--- a/src/Template/Admin/QueuedJobs/data.ctp
+++ b/src/Template/Admin/QueuedJobs/data.ctp
@@ -12,6 +12,8 @@
 	</ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
+	<h1><?= __d('queue', 'Edit') ?></h1>
+
 	<?= $this->Form->create($queuedJob) ?>
 	<fieldset>
 		<legend><?= __d('queue', 'Edit Queued Job Payload') ?></legend>

--- a/src/Template/Admin/QueuedJobs/edit.ctp
+++ b/src/Template/Admin/QueuedJobs/edit.ctp
@@ -19,6 +19,8 @@
 	</ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
+	<h1><?= __d('queue', 'Edit') ?></h1>
+
 	<?= $this->Form->create($queuedJob) ?>
 	<fieldset>
 		<legend><?= __d('queue', 'Edit Queued Job') ?></legend>

--- a/src/Template/Admin/QueuedJobs/execute.ctp
+++ b/src/Template/Admin/QueuedJobs/execute.ctp
@@ -11,6 +11,8 @@
 	</ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
+	<h1><?= __d('queue', 'Add Execute Jobs') ?></h1>
+
 	<?= $this->Form->create(null) ?>
 	<fieldset>
 		<legend><?= __d('queue', 'Trigger Execute Job') ?></legend>

--- a/src/Template/Admin/QueuedJobs/import.ctp
+++ b/src/Template/Admin/QueuedJobs/import.ctp
@@ -10,7 +10,7 @@
 	</ul>
 </nav>
 <div class="releases form large-9 medium-8 columns content">
-	<h2>Import</h2>
+	<h1>Import</h1>
 
 	<?= $this->Form->create(null, ['type' => 'file']) ?>
 	<fieldset>

--- a/src/Template/Admin/QueuedJobs/index.ctp
+++ b/src/Template/Admin/QueuedJobs/index.ctp
@@ -16,6 +16,13 @@ use Cake\Core\Plugin;
 		<li><?= $this->Html->link(__d('queue', 'Import'), ['action' => 'import']) ?></li>
 		<?php } ?>
 	</ul>
+
+	<hr>
+
+	<?= __d('queue', 'Current server time') ?>:
+	<br>
+	<?php echo $this->Time->nice(new \Cake\I18n\FrozenTime()); ?>
+
 </nav>
 <div class="content action-index index large-9 medium-8 columns col-sm-8 col-xs-12">
 
@@ -56,18 +63,41 @@ use Cake\Core\Plugin;
 					?>
 				</td>
 				<td><?= $this->Time->nice($queuedJob->created) ?></td>
-				<td><?= $this->Time->nice($queuedJob->notbefore) ?></td>
+				<td>
+					<?= $this->Time->nice($queuedJob->notbefore) ?>
+					<br>
+					<?php echo $this->QueueProgress->timeoutProgressBar($queuedJob, 8); ?>
+					<?php if ($queuedJob->notbefore) {
+						echo '<div><small>';
+						echo $this->Time->relLengthOfTime($queuedJob->notbefore);
+						echo '</small></div>';
+					} ?>
+				</td>
 				<td>
 					<?= $this->Time->nice($queuedJob->fetched) ?>
 
-					<div><small><code><?php echo h($queuedJob->workerkey); ?></code></small></div>
-					<?php if ($queuedJob->progress) { ?>
-						<div><?php echo $this->Number->toPercentage($queuedJob->progress * 100, 0); ?></div>
+					<?php if ($queuedJob->fetched) {
+						echo '<div><small>';
+						echo $this->Time->relLengthOfTime($queuedJob->fetched);
+						echo '</small></div>';
+					} ?>
+
+					<?php if ($queuedJob->workerkey) { ?>
+						<div><small><code><?php echo h($queuedJob->workerkey); ?></code></small></div>
 					<?php } ?>
 				</td>
 				<td><?= $this->Time->nice($queuedJob->completed) ?></td>
 				<td><?= $this->Number->format($queuedJob->failed) ?></td>
-				<td><?= h($queuedJob->status) ?></td>
+				<td>
+					<?= h($queuedJob->status) ?>
+					<?php if ($queuedJob->fetched) { ?>
+						<div>
+							<?php echo $this->QueueProgress->progress($queuedJob) ?>
+							<br>
+							<?php echo $this->QueueProgress->progressBar($queuedJob, 8); ?>
+						</div>
+					<?php } ?>
+				</td>
 				<td><?= $this->Number->format($queuedJob->priority) ?></td>
 				<td class="actions">
 				<?= $this->Html->link($this->Format->icon('view'), ['action' => 'view', $queuedJob->id], ['escapeTitle' => false]); ?>

--- a/src/Template/Admin/QueuedJobs/test.ctp
+++ b/src/Template/Admin/QueuedJobs/test.ctp
@@ -2,6 +2,7 @@
 /**
  * @var \App\View\AppView $this
  * @var \Queue\Model\Entity\QueuedJob $queuedJob
+ * @var string[] $tasks
  */
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">

--- a/src/Template/Admin/QueuedJobs/test.ctp
+++ b/src/Template/Admin/QueuedJobs/test.ctp
@@ -12,6 +12,8 @@
 	</ul>
 </nav>
 <div class="content action-form form large-9 medium-8 columns col-sm-8 col-xs-12">
+	<h1><?= __d('queue', 'Create test jobs') ?></h1>
+
 	<?= $this->Form->create($queuedJob) ?>
 	<fieldset>
 		<legend><?= __d('queue', 'Trigger Delayed Job') ?></legend>

--- a/src/Template/Admin/QueuedJobs/view.ctp
+++ b/src/Template/Admin/QueuedJobs/view.ctp
@@ -18,7 +18,7 @@
 	</ul>
 </nav>
 <div class="content action-view view large-9 medium-8 columns col-sm-8 col-xs-12">
-	<h2><?= h($queuedJob->id) ?></h2>
+	<h1><?= h($queuedJob->id) ?></h1>
 	<table class="table vertical-table">
 		<tr>
 			<th><?= __d('queue', 'Job Type') ?></th>

--- a/src/Template/Admin/QueuedJobs/view.ctp
+++ b/src/Template/Admin/QueuedJobs/view.ctp
@@ -38,19 +38,50 @@
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Notbefore') ?></th>
-			<td><?= $this->Time->nice($queuedJob->notbefore) ?></td>
+			<td>
+				<?= $this->Time->nice($queuedJob->notbefore) ?>
+				<br>
+				<?php echo $this->QueueProgress->timeoutProgressBar($queuedJob, 18); ?>
+				<?php if ($queuedJob->notbefore) {
+					echo '<div><small>';
+					echo $this->Time->relLengthOfTime($queuedJob->notbefore);
+					echo '</small></div>';
+				} ?>
+			</td>
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Fetched') ?></th>
-			<td><?= $this->Time->nice($queuedJob->fetched) ?></td>
+			<td>
+				<?= $this->Time->nice($queuedJob->fetched) ?>
+				<?php if ($queuedJob->fetched) {
+					echo '<div><small>';
+					echo $this->Time->duration($queuedJob->fetched->diff($queuedJob->created));
+					echo '</small></div>';
+				} ?>
+			</td>
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Completed') ?></th>
-			<td><?= $this->Time->nice($queuedJob->completed) ?></td>
+			<td>
+				<?= $this->Time->nice($queuedJob->completed) ?>
+				<?php if ($queuedJob->completed) {
+					echo '<div><small>';
+					echo $this->Time->duration($queuedJob->completed->diff($queuedJob->fetched));
+					echo '</small></div>';
+				} ?>
+			</td>
+		</tr>
+		<tr>
+			<th><?= __d('queue', 'Status') ?></th>
+			<td><?= h($queuedJob->status) ?></td>
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Progress') ?></th>
-			<td><?= $queuedJob->progress ? $this->Number->toPercentage($queuedJob->progress * 100, 0) : '' ?></td>
+			<td>
+				<?php echo $this->QueueProgress->progress($queuedJob) ?>
+				<br>
+				<?php echo $this->QueueProgress->progressBar($queuedJob, 18); ?>
+			</td>
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Failed') ?></th>
@@ -58,7 +89,7 @@
 				<?= $queuedJob->failed ? $this->Number->format($queuedJob->failed) . 'x' : '' ?>
 				<?php
 				if ($queuedJob->fetched && $queuedJob->failed) {
-					echo ' ' . $this->Form->postLink('Soft reset', ['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id], ['confirm' => 'Sure?', 'class' => 'button button-primary btn margin btn-primary']);
+					echo ' ' . $this->Form->postLink(__d('queue', 'Soft reset'), ['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id], ['confirm' => 'Sure?', 'class' => 'button button-primary btn margin btn-primary']);
 				}
 				?>
 			</td>
@@ -71,10 +102,6 @@
 					[<?php echo $this->Html->link($queuedJob->worker_process->server ?: $queuedJob->worker_process->pid, ['controller' => 'QueueProcesses', 'action' => 'view', $queuedJob->worker_process->id]); ?>]
 				<?php } ?>
 			</td>
-		</tr>
-		<tr>
-			<th><?= __d('queue', 'Status') ?></th>
-			<td><?= h($queuedJob->status) ?></td>
 		</tr>
 		<tr>
 			<th><?= __d('queue', 'Priority') ?></th>

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -75,8 +75,10 @@ class QueueProgressHelper extends Helper {
 	}
 
 	/**
+	 * Returns percentage as visual progress bar.
+	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 * @param $length
+	 * @param int $length
 	 * @return string|null
 	 */
 	public function timeoutProgressBar(QueuedJob $queuedJob, $length) {
@@ -92,7 +94,6 @@ class QueueProgressHelper extends Helper {
 	 * Calculates the timeout progress rate.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return float|null
 	 */
 	protected function calculateTimeoutProgress(QueuedJob $queuedJob) {

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -1,0 +1,186 @@
+<?php
+namespace Queue\View\Helper;
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\Datasource\ModelAwareTrait;
+use Cake\I18n\FrozenTime;
+use Cake\I18n\Number;
+use Cake\View\Helper;
+use Queue\Model\Entity\QueuedJob;
+
+/**
+ * @property \Tools\View\Helper\ProgressHelper $Progress
+ * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
+ */
+class QueueProgressHelper extends Helper {
+
+	use ModelAwareTrait;
+
+	/**
+	 * @var array
+	 */
+	public $helpers = [
+		'Tools.Progress',
+	];
+
+	/**
+	 * @var array|null
+	 */
+	protected $statistics;
+
+	/**
+	 * Returns percentage as formatted value.
+	 *
+	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 * @return string|null
+	 */
+	public function progress(QueuedJob $queuedJob) {
+		if ($queuedJob->completed) {
+			return null;
+		}
+
+		if ($queuedJob->progress === null && $queuedJob->fetched) {
+			$queuedJob->progress = $this->calculateJobProgress($queuedJob->job_type, $queuedJob->fetched);
+		}
+
+		if ($queuedJob->progress === null) {
+			return null;
+		}
+
+		return Number::toPercentage($queuedJob->progress, 0, ['multiply' => true]);
+	}
+
+	/**
+	 * Returns percentage as visual progress bar.
+	 *
+	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 * @param int $length
+	 * @return string|null
+	 */
+	public function progressBar(QueuedJob $queuedJob, $length) {
+		if ($queuedJob->completed) {
+			return null;
+		}
+
+		if ($queuedJob->progress === null && $queuedJob->fetched) {
+			$queuedJob->progress = $this->calculateJobProgress($queuedJob->job_type, $queuedJob->fetched);
+		}
+
+		if ($queuedJob->progress === null) {
+			return null;
+		}
+
+		return $this->Progress->progressBar($queuedJob->progress, $length);
+	}
+
+	/**
+	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 * @param $length
+	 * @return string|null
+	 */
+	public function timeoutProgressBar(QueuedJob $queuedJob, $length) {
+		$progress = $this->calculateTimeoutProgress($queuedJob);
+		if (!$progress) {
+			return null;
+		}
+
+		return $this->Progress->progressBar($progress, $length);
+	}
+
+	/**
+	 * Calculates the timeout progress rate.
+	 *
+	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
+	 * @return float|null
+	 */
+	protected function calculateTimeoutProgress(QueuedJob $queuedJob) {
+		if ($queuedJob->completed || $queuedJob->fetched || !$queuedJob->notbefore) {
+			return null;
+		}
+
+		$created = $queuedJob->created->getTimestamp();
+		$planned = $queuedJob->notbefore->getTimestamp();
+		$now = (new FrozenTime())->getTimestamp();
+
+		$progressed = $now - $created;
+		$total = $planned - $created;
+
+		if ($total <= 0) {
+			return null;
+		}
+
+		if ($progressed <= 0) {
+			$progressed = $total;
+		}
+
+		$progress = min($progressed / $total, 1.0);
+
+		return (float)$progress;
+	}
+
+	/**
+	 * @param string $jobType
+	 * @param \Cake\I18n\FrozenTime|\Cake\I18n\Time $fetched
+	 * @return float|null
+	 */
+	protected function calculateJobProgress($jobType, $fetched) {
+		$stats = $this->getJobStatistics($jobType);
+		if (!$stats) {
+			return null;
+		}
+
+		$average = array_sum($stats) / count($stats);
+		$running = $fetched->diffInSeconds();
+
+		$progress = min($running / $average, 0.9999);
+
+		return (float)$progress;
+	}
+
+	/**
+	 * @param string $jobType
+	 * @return array
+	 */
+	protected function getJobStatistics($jobType) {
+		$statistics = $this->readStatistics();
+		if (!isset($statistics[$jobType])) {
+			return [];
+		}
+
+		return $statistics[$jobType];
+	}
+
+	const KEY = 'queue_queued-job-statistics';
+	const CONFIG = 'default';
+
+	/**
+	 * @return array
+	 */
+	protected function readStatistics() {
+		if ($this->statistics !== null) {
+			return $this->statistics;
+		}
+
+		$queuedJobStatistics = false;
+		if (!Configure::read('debug')) {
+			$queuedJobStatistics = Cache::read(static::KEY, static::CONFIG);
+		}
+		if ($queuedJobStatistics === false) {
+			$this->loadModel('Queue.QueuedJobs');
+			$queuedJobStatistics = $this->QueuedJobs->getStats()->disableHydration()->toArray();
+			Cache::write(static::KEY, $queuedJobStatistics, static::CONFIG);
+		}
+
+		$statistics = [];
+		foreach ($queuedJobStatistics as $statistic) {
+			$statistics[$statistic['job_type']][] = $statistic['runtime'];
+		}
+
+		$this->statistics = $statistics;
+
+		return $this->statistics;
+	}
+
+}

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Queue\Test\TestCase\View\Helper;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\I18n\FrozenTime;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Queue\Model\Entity\QueuedJob;
+use Queue\View\Helper\QueueProgressHelper;
+
+class QueueProgressHelperTest extends TestCase {
+
+	/**
+	 * @var array
+	 */
+	public $fixtures = [
+		'plugin.queue.QueuedJobs',
+	];
+
+	/**
+	 * @var \Queue\View\Helper\QueueProgressHelper
+	 */
+	protected $QueueProgressHelper;
+
+	/**
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->QueueProgressHelper = new QueueProgressHelper(new View(null));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProgressBar() {
+		$queuedJob = new QueuedJob([
+			'progress' => 0.47,
+		]);
+		$result = $this->QueueProgressHelper->progressBar($queuedJob, 5);
+		$this->assertTextContains('<span title="47%">', $result);
+
+		$queuedJob = new QueuedJob([
+			'progress' => null,
+		]);
+		$result = $this->QueueProgressHelper->progressBar($queuedJob, 5);
+		$this->assertNull($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testProgressBarByStatistics() {
+		$this->_needsConnection();
+
+		/** @var \Queue\Model\Entity\QueuedJob $queuedJob */
+		$queuedJob = TableRegistry::get('Queue.QueuedJobs')->newEntity([
+			'job_type' => 'Foo',
+			'created' => (new FrozenTime())->subHour(),
+			'fetched' => (new FrozenTime())->subHour(),
+			'completed' => (new FrozenTime())->subHour()->addMinutes(10),
+		]);
+		TableRegistry::get('Queue.QueuedJobs')->saveOrFail($queuedJob);
+
+		$queuedJob->completed = null;
+		$queuedJob->fetched = (new FrozenTime())->subMinute();
+
+		$result = $this->QueueProgressHelper->progressBar($queuedJob, 5);
+		$this->assertTextContains('<span title="10%">', $result);
+	}
+
+	/**
+	 * Helper method for skipping tests that need a real connection.
+	 *
+	 * @return void
+	 */
+	protected function _needsConnection() {
+		$config = ConnectionManager::getConfig('test');
+		$this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Only Mysql is working yet for this.');
+	}
+
+}

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -72,6 +72,19 @@ class QueueProgressHelperTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testTimeoutProgressBar() {
+		$queuedJob = new QueuedJob([
+			'created' => (new FrozenTime())->subHour(),
+			'notbefore' => (new FrozenTime())->addHour(),
+		]);
+
+		$result = $this->QueueProgressHelper->timeoutProgressBar($queuedJob, 5);
+		$this->assertTextContains('<span title="50%">', $result);
+	}
+
+	/**
 	 * Helper method for skipping tests that need a real connection.
 	 *
 	 * @return void


### PR DESCRIPTION
Using Tools plugin 1.9.6+ you can also use the more visual progress bar (or any custom one of yours):
```php
echo $this->QueueProgress->progressBar($queuedJob, 18);
```
The length refers to the amount of chars to display.

Make sure you loaded the helper in your AppView class.

By default it first tries to use the actual `progress` stored as value 0...1.
If that field is `null`, it tries to use the statistics of previously finished jobs of the same task
to determine average length and displays the progress based on this.