### PR TITLE
Only do MySQL specific migrations for MySQL

### DIFF
--- a/config/Migrations/20161319000000_increase_data_size.php
+++ b/config/Migrations/20161319000000_increase_data_size.php
@@ -17,21 +17,23 @@ class IncreaseDataSize extends AbstractMigration {
 	 * @return void
 	 */
 	public function change() {
-		$table = $this->table('queued_tasks');
+		if ($this->adapter instanceof \Phinx\Db\Adapter\MysqlAdapter) {	
+			$table = $this->table('queued_tasks');
 
-		try {
-			$adapter = new MysqlAdapter([]);
-			if ($adapter->getSqlType('text', 'longtext')) {
-				$table->changeColumn('data', 'text', [
-					'limit' => MysqlAdapter::TEXT_LONG,
-					'null' => true,
-					'default' => null,
-				]);
+			try {
+				$adapter = new MysqlAdapter([]);
+				if ($adapter->getSqlType('text', 'longtext')) {
+					$table->changeColumn('data', 'text', [
+						'limit' => MysqlAdapter::TEXT_LONG,
+						'null' => true,
+						'default' => null,
+					]);
 
-				$table->save();
+					$table->save();
+				}
+			} catch (Exception $e) {
+				Debugger::dump($e->getMessage());
 			}
-		} catch (Exception $e) {
-			Debugger::dump($e->getMessage());
 		}
 	}
 

--- a/config/Migrations/20171013131845_AlterQueuedJobs.php
+++ b/config/Migrations/20171013131845_AlterQueuedJobs.php
@@ -17,22 +17,23 @@ class AlterQueuedJobs extends AbstractMigration {
 	 * @return void
 	 */
 	public function change() {
-		$table = $this->table('queued_jobs');
+		if ($this->adapter instanceof \Phinx\Db\Adapter\MysqlAdapter) {
+			$table = $this->table('queued_jobs');
 
-		try {
-			$adapter = new MysqlAdapter([]);
-			if ($adapter->getSqlType('text', 'mediumtext')) {
-				$table->changeColumn('failure_message', 'text', [
-					'limit' => MysqlAdapter::TEXT_MEDIUM,
-					'null' => true,
-					'default' => null,
-				]);
+			try {
+				$adapter = new MysqlAdapter([]);
+				if ($adapter->getSqlType('text', 'mediumtext')) {
+					$table->changeColumn('failure_message', 'text', [
+						'limit' => MysqlAdapter::TEXT_MEDIUM,
+						'null' => true,
+						'default' => null,
+					]);
 
-				$table->save();
+					$table->save();
+				}
+			} catch (Exception $e) {
+				Debugger::dump($e->getMessage());
 			}
-		} catch (Exception $e) {
-			Debugger::dump($e->getMessage());
 		}
 	}
-
 }

--- a/config/Migrations/20171013133145_Utf8mb4Fix.php
+++ b/config/Migrations/20171013133145_Utf8mb4Fix.php
@@ -66,25 +66,27 @@ class Utf8mb4Fix extends AbstractMigration {
 		$table->update();
 
 		//TODO: check adapter and skip for postgres, instead of try/catch
-		try {
-			$table = $this->table('queued_jobs');
-			$table->changeColumn('data', 'text', [
-				'limit' => MysqlAdapter::TEXT_MEDIUM,
-				'null' => true,
-				'default' => null,
-				'encoding' => 'utf8mb4',
-				'collation' => 'utf8mb4_unicode_ci',
-			]);
-			$table->changeColumn('failure_message', 'text', [
-				'limit' => MysqlAdapter::TEXT_MEDIUM,
-				'null' => true,
-				'default' => null,
-				'encoding' => 'utf8mb4',
-				'collation' => 'utf8mb4_unicode_ci',
-			]);
-			$table->update();
-		} catch (Exception $e) {
-			Debugger::dump($e->getMessage());
+		if ($this->adapter instanceof \Phinx\Db\Adapter\MysqlAdapter) {
+			try {
+				$table = $this->table('queued_jobs');
+				$table->changeColumn('data', 'text', [
+					'limit' => MysqlAdapter::TEXT_MEDIUM,
+					'null' => true,
+					'default' => null,
+					'encoding' => 'utf8mb4',
+					'collation' => 'utf8mb4_unicode_ci',
+				]);
+				$table->changeColumn('failure_message', 'text', [
+					'limit' => MysqlAdapter::TEXT_MEDIUM,
+					'null' => true,
+					'default' => null,
+					'encoding' => 'utf8mb4',
+					'collation' => 'utf8mb4_unicode_ci',
+				]);
+				$table->update();
+			} catch (Exception $e) {
+				Debugger::dump($e->getMessage());
+			}
 		}
 	}
 


### PR DESCRIPTION
I'm using Postgres 11 and the migrations below failed on a freshly installed migration. Code now uses existing try catch (which appeared ineffective in my case) as well as a test instance of condition.

Hopefully this makes sense and incorporation in the code base will make it better for Postgres users.