### PR TITLE
Fix: Postgres error on runworker

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -473,6 +473,8 @@ class QueuedJobsTable extends Table {
 			if (array_key_exists('rate', $task) && $tmp['job_type'] && array_key_exists($tmp['job_type'], $this->rateHistory)) {
 				switch ($driverName) {
 					case static::DRIVER_POSTGRES:
+						$tmp["EXTRACT(EPOCH FROM NOW()) >="] = $this->rateHistory[$tmp['job_type']] + $task['rate'];
+						break;
 					case static::DRIVER_MYSQL:
 						$tmp['UNIX_TIMESTAMP() >='] = $this->rateHistory[$tmp['job_type']] + $task['rate'];
 						break;

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -473,7 +473,7 @@ class QueuedJobsTable extends Table {
 			if (array_key_exists('rate', $task) && $tmp['job_type'] && array_key_exists($tmp['job_type'], $this->rateHistory)) {
 				switch ($driverName) {
 					case static::DRIVER_POSTGRES:
-						$tmp["EXTRACT(EPOCH FROM NOW()) >="] = $this->rateHistory[$tmp['job_type']] + $task['rate'];
+						$tmp['EXTRACT(EPOCH FROM NOW()) >='] = $this->rateHistory[$tmp['job_type']] + $task['rate'];
 						break;
 					case static::DRIVER_MYSQL:
 						$tmp['UNIX_TIMESTAMP() >='] = $this->rateHistory[$tmp['job_type']] + $task['rate'];


### PR DESCRIPTION
This PR fix runworker error for Postgresql

	Job Finished.
	---------------------------------------------------------------
	[2019-09-08 23:43:12] Looking for Job ...
	Exception: SQLSTATE[42883]: Undefined function: 7 ERROR:  function unix_timestamp() does not exist
	LINE 1: ...d < $3 OR (fetched) IS NULL)) AND failed < $4 AND UNIX_TIMES...
                                                             ^
