### PR TITLE
Update QueuedJobsTable.php

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -123,12 +123,12 @@ class QueuedJobsTable extends Table {
 					if ($status === 'completed') {
 						$query->where(['completed IS NOT' => null]);
 
-						return $query;
+						return true;
 					}
 					if ($status === 'in_progress') {
 						$query->where(['completed IS' => null]);
 
-						return $query;
+						return true;
 					}
 
 					throw new NotImplementedException('Invalid status type');


### PR DESCRIPTION
Newer versions of FriendsOfCake/search declare the return value of the callback function to be a boolean. Returning the query results in errors:

`Return value of Search\Model\Filter\Callback::process() must be of the type boolean, object returned`