### PR TITLE
Fix sending signal from CGI

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -21,6 +21,9 @@ use RuntimeException;
 if (!defined('SIGTERM')) {
 	define('SIGTERM', 15);
 }
+if (!defined('SIGUSR1')) {
+	define('SIGUSR1', 10);
+}
 
 /**
  * @author MGriesbach@gmail.com


### PR DESCRIPTION
This is a fix for #228.

For some reason, when running from a CGI such as php-fpm, PCNTL signals constants are not defined and `posix_kill()` fails to send the signal. Yet the constants are defined when running from CLI, which is very confusing.

This is exactly the behavior Martin mentioned [here](https://www.php.net/manual/fr/function.posix-kill.php#117225).