### PR TITLE
Fix sending signal from CGI (2)

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -987,7 +987,8 @@ class QueuedJobsTable extends Table {
 	}
 
 	/**
-	 * Sends a SIGUSR1 to all workers of this server.
+	 * Sends a SIGUSR1 to all workers. This will only affect workers
+	 * running with config option canInterruptSleep set to true.
 	 *
 	 * @return void
 	 */
@@ -995,7 +996,7 @@ class QueuedJobsTable extends Table {
 		if (!function_exists('posix_kill')) {
 			return;
 		}
-		$processes = $this->getProcesses(true);
+		$processes = $this->getProcesses();
 		foreach ($processes as $pid => $modified) {
 			if ($pid > 0) {
 				posix_kill($pid, SIGUSR1);


### PR DESCRIPTION
This is another fix for #228.

I thought it would make sense to use `true` to restrict the processes to the ones running on the same server. However, it doesn’t seem to work as expected, because buildServerString() returns the fully qualified host name
(such as www.example.com) when running in php-fpm, whereas it returns the "internal" host name (as returned by gethostname()) when running from the cake console. As a result, the CGI code mistakenly assumes the worker process is running on a different machine and avoids sending the signal. This PR makes it working out of the box for users willing to send a signal from CGI to CLI.