### PR TITLE
Add Reusable emails support for Email task

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -674,8 +674,8 @@ Or send reusable Emails via the Mailer object:
 ```php
 $data = [
     'settings' => $mailerObject,
-    'action' => 'myReusableEmail',
-    'actionVars' => [$var1, $var2, $var3]
+    'action' => 'myReusableEmail', // instead of content or headers
+    'vars' => [$var1, $var2, $var3]
 ];
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -670,6 +670,15 @@ $data = [
 ];
 ```
 
+Or send reusable Emails via the Mailer object:
+```php
+$data = [
+    'settings' => $mailerObject,
+    'action' => 'myReusableEmail',
+    'actionVars' => [$var1, $var2, $var3]
+];
+```
+
 Inside a controller you can for example do this for your mailers:
 ```php
 $mailer = $this->getMailer('User');

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -116,8 +116,8 @@ class EmailTask extends Task implements AddInterface {
 				$mailer->setTransport($data['transport'] ?? 'default');
 
 				// Check if a reusable email should be sent
-				if (!empty($data['action']) && !empty($data['actionVars'])) {
-					$result = $mailer->send($data['action'], $data['actionVars']);
+				if (!empty($data['action'])) {
+					$result = $mailer->send($data['action'], $data['actionVars'] ?? []);
 				} else {
 					$content = isset($data['content']) ? $data['content'] : '';
 					$result = $mailer->deliver($content);

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -117,7 +117,7 @@ class EmailTask extends Task implements AddInterface {
 
 				// Check if a reusable email should be sent
 				if (!empty($data['action'])) {
-					$result = $mailer->send($data['action'], $data['actionVars'] ?? []);
+					$result = $mailer->send($data['action'], $data['vars'] ?? []);
 				} else {
 					$content = isset($data['content']) ? $data['content'] : '';
 					$result = $mailer->deliver($content);

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -114,8 +114,15 @@ class EmailTask extends Task implements AddInterface {
 			$result = null;
 			try {
 				$mailer->setTransport($data['transport'] ?? 'default');
-				$content = isset($data['content']) ? $data['content'] : '';
-				$result = $mailer->deliver($content);
+
+				// Check if a reusable email should be sent
+				if(!empty($data['action']) && !empty($data['actionVars'])) {
+					$result = $mailer->send($data['action'], $data['actionVars']);
+				} else {
+					$content = isset($data['content']) ? $data['content'] : '';
+					$result = $mailer->deliver($content);
+				}
+
 
 			} catch (Throwable $e) {
 				$error = $e->getMessage();

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -116,13 +116,12 @@ class EmailTask extends Task implements AddInterface {
 				$mailer->setTransport($data['transport'] ?? 'default');
 
 				// Check if a reusable email should be sent
-				if(!empty($data['action']) && !empty($data['actionVars'])) {
+				if (!empty($data['action']) && !empty($data['actionVars'])) {
 					$result = $mailer->send($data['action'], $data['actionVars']);
 				} else {
 					$content = isset($data['content']) ? $data['content'] : '';
 					$result = $mailer->deliver($content);
 				}
-
 
 			} catch (Throwable $e) {
 				$error = $e->getMessage();


### PR DESCRIPTION
Closes #282 

This adds support for reusable emails for the Email task.

Basically I introduced 2 new keys in the $data array: `action` and `actionVars`.
If both are present they will be used to send the desired reusable email.

Otherwise if either one of those keys is not present the default `->deliver($content)` logic persists.