### PR TITLE
Commands php73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4']
+        php-version: ['7.3', '7.4']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '7.3'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 
@@ -72,7 +72,7 @@ jobs:
         if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
         if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
         if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-        if [[ ${{ matrix.php-version }} == '7.2' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+        if [[ ${{ matrix.php-version }} == '7.3' && ${{ matrix.db-type }} == 'sqlite' ]]; then
           vendor/bin/phpunit --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
@@ -82,7 +82,7 @@ jobs:
       run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
     - name: Code Coverage Report
-      if: success() && matrix.php-version == '7.2' && matrix.db-type == 'sqlite'
+      if: success() && matrix.php-version == '7.3' && matrix.db-type == 'sqlite'
       uses: codecov/codecov-action@v1
 
   validation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Composer install --no-progress --prefer-dist --optimize-autoloader
       run: |
         composer --version
-        composer require --dev phpunit/phpunit:"^8.5"
+        composer require --dev phpunit/phpunit:"^9.5"
         if ${{ matrix.prefer-lowest == 'prefer-lowest' }}
         then
           composer update --prefer-lowest --prefer-stable

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 [![CI](https://github.com/dereuromark/cakephp-queue/workflows/CI/badge.svg?branch=master)](https://github.com/dereuromark/cakephp-queue/actions?query=workflow%3ACI+branch%3Amaster)
 [![Coverage Status](https://img.shields.io/codecov/c/github/dereuromark/cakephp-queue/master.svg)](https://codecov.io/github/dereuromark/cakephp-queue/branch/master)
 [![Latest Stable Version](https://poser.pugx.org/dereuromark/cakephp-queue/v/stable.svg)](https://packagist.org/packages/dereuromark/cakephp-queue)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.3-8892BF.svg)](https://php.net/)
 [![License](https://poser.pugx.org/dereuromark/cakephp-queue/license)](https://packagist.org/packages/dereuromark/cakephp-queue)
 [![Total Downloads](https://poser.pugx.org/dereuromark/cakephp-queue/d/total)](https://packagist.org/packages/dereuromark/cakephp-queue)
 [![Coding Standards](https://img.shields.io/badge/cs-PSR--2--R-yellow.svg)](https://github.com/php-fig-rectified/fig-rectified-standards)
 
-This branch is for use with **CakePHP 4.0+**. For details see [version map](https://github.com/dereuromark/cakephp-queue/wiki#cakephp-version-map).
+This branch is for use with **CakePHP 4.2+**. For details see [version map](https://github.com/dereuromark/cakephp-queue/wiki#cakephp-version-map).
 
 
 ## Background

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2",
-		"cakephp/cakephp": "^4.0.4"
+		"php": ">=7.3",
+		"cakephp/cakephp": "^4.2.0"
 	},
 	"require-dev": {
 		"friendsofcake/search": "^6.0.0",
@@ -55,7 +55,7 @@
 		"stan-tests": "phpstan analyse -c tests/phpstan.neon",
 		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 && mv composer.backup composer.json",
 		"test": "php phpunit.phar",
-		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-8.5.2.phar && mv phpunit-8.5.2.phar phpunit.phar || true",
+		"test-setup": "[ ! -f phpunit.phar ] && wget https://phar.phpunit.de/phpunit-9.5.4.phar && mv phpunit-9.5.4.phar phpunit.phar || true",
 		"cs-check": "phpcs -p -s --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=/config/Migrations/ --extensions=php src/ tests/ config/",
 		"cs-fix": "phpcbf -p --standard=vendor/fig-r/psr2r-sniffer/PSR2R/ruleset.xml --ignore=/config/Migrations/ --extensions=php src/ tests/ config/"
 	},

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
 	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
 	earlyTerminatingMethodCalls:
-		Cake\Console\Shell:
+		Cake\Command\Command:
 			- abort
 	ignoreErrors:
 		- '#Access to an undefined property Cake\\ORM\\BehaviorRegistry::\$Search#'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -105,24 +105,23 @@ Cake\Mailer\TransportFactory::setConfig('default', [
 */
 
 // Allow local overwrite
-// E.g. in your console: export db_dsn="mysql://root:secret@127.0.0.1/cake_test"
-if (!getenv('db_class') && getenv('db_dsn')) {
-	ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
+// E.g. in your console: export DB_URL="mysql://root:secret@127.0.0.1/cake_test"
+if (getenv('DB_URL')) {
+	ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
 
 	return;
 }
-if (!getenv('db_class')) {
-	putenv('db_class=Cake\Database\Driver\Sqlite');
-	putenv('db_dsn=sqlite::memory:');
+if (!getenv('DB_CLASS')) {
+	putenv('DB_CLASS=Cake\Database\Driver\Sqlite');
+	putenv('DB_URL=sqlite::memory:');
 }
 
 // Uses Travis config then (MySQL, Postgres, ...)
 ConnectionManager::setConfig('test', [
 	'className' => 'Cake\Database\Connection',
-	'driver' => getenv('db_class') ?: null,
-	'dsn' => getenv('db_dsn') ?: null,
+	'driver' => getenv('DB_CLASS') ?: null,
+	'url' => getenv('DB_URL') ?: null,
 	'timezone' => 'UTC',
 	'quoteIdentifiers' => false,
 	'cacheMetadata' => true,
-
 ]);


### PR DESCRIPTION
Require
- PHP 7.3+
- CakePHP 4.2+

Is this OK for v6.0 or should we do this later this year?
What do people think?