### PR TITLE
CakePHP 4.3 - update routes.php to use RouteBuilder

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,16 +1,18 @@
 <?php
 
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Router;
 
-Router::prefix('Admin', function (RouteBuilder $routes) {
-	$routes->plugin('Queue', function (RouteBuilder $routes) {
-		$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
+return static function (RouteBuilder $outer_routes) {
+	$outer_routes->prefix('Admin', function (RouteBuilder $routes) {
+		$routes->plugin('Queue', function (RouteBuilder $routes) {
+			$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
 
-		$routes->fallbacks();
+			$routes->fallbacks();
+		});
 	});
-});
 
-Router::plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
-	$routes->connect('/:controller');
-});
+	$outer_routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
+		$routes->connect('/:controller');
+	});
+};
+

--- a/config/routes.php
+++ b/config/routes.php
@@ -2,8 +2,8 @@
 
 use Cake\Routing\RouteBuilder;
 
-return static function (RouteBuilder $outer_routes) {
-	$outer_routes->prefix('Admin', function (RouteBuilder $routes) {
+return static function (RouteBuilder $routes) {
+	$routes->prefix('Admin', function (RouteBuilder $routes) {
 		$routes->plugin('Queue', function (RouteBuilder $routes) {
 			$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
 
@@ -11,7 +11,7 @@ return static function (RouteBuilder $outer_routes) {
 		});
 	});
 
-	$outer_routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
+	$routes->plugin('Queue', [ 'path' => '/queue'], function (RouteBuilder $routes) {
 		$routes->connect('/:controller');
 	});
 };


### PR DESCRIPTION
This fixes the deprecation errors being thrown when using the current CakePHP 4.3 RC1 version