### PR TITLE
fix CakePHP 4.3 deprecation warnings in routes.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	],
 	"require": {
 		"php": ">=7.2",
-		"cakephp/cakephp": "dev-4.next as 4.1.7"
+		"cakephp/cakephp": "^4.1.7"
 	},
 	"require-dev": {
 		"cakephp/bake": "^2.5.0",

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,5 +1,7 @@
 <?php
-/** @var RouteBuilder $routes */
+/**
+ * @var RouteBuilder $routes
+ */
 
 use Cake\Routing\RouteBuilder;
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -14,5 +14,5 @@ $routes->prefix('Admin', function (RouteBuilder $routes) {
 });
 
 $routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
-	$routes->connect('/:controller');
+	$routes->connect('/{controller}');
 });

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,16 +1,17 @@
 <?php
 
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Router;
 
-Router::prefix('Admin', function (RouteBuilder $routes) {
-	$routes->plugin('Queue', function (RouteBuilder $routes) {
-		$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
+return function (RouteBuilder $routes) {
+	$routes->prefix('Admin', function (RouteBuilder $routes) {
+		$routes->plugin('Queue', function (RouteBuilder $routes) {
+			$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
 
-		$routes->fallbacks();
+			$routes->fallbacks();
+		});
 	});
-});
 
-Router::plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
-	$routes->connect('/:controller');
-});
+	$routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
+		$routes->connect('/:controller');
+	});
+};

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,17 +1,16 @@
 <?php
+/** @var RouteBuilder $routes */
 
 use Cake\Routing\RouteBuilder;
 
-return function (RouteBuilder $routes) {
-	$routes->prefix('Admin', function (RouteBuilder $routes) {
-		$routes->plugin('Queue', function (RouteBuilder $routes) {
-			$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
+$routes->prefix('Admin', function (RouteBuilder $routes) {
+	$routes->plugin('Queue', function (RouteBuilder $routes) {
+		$routes->connect('/', ['controller' => 'Queue', 'action' => 'index']);
 
-			$routes->fallbacks();
-		});
+		$routes->fallbacks();
 	});
+});
 
-	$routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
-		$routes->connect('/:controller');
-	});
-};
+$routes->plugin('Queue', ['path' => '/queue'], function (RouteBuilder $routes) {
+	$routes->connect('/:controller');
+});


### PR DESCRIPTION
Fixes #303

I am not able to run all tests locally because I am not on Linux (and your tests require linux)

But this actually fixes the deprecation warning in CakePHP 4.3 but should still be backwards compatible.