### PR TITLE
fix LoadHelperTrait not setting config correctly

### DIFF
--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -11,7 +11,7 @@ trait LoadHelperTrait {
 	 */
 	protected function loadHelpers(): void {
 		$helpers = [
-			'Time' => ['config' => ['class' => 'Tools.Time', 'engine' => 'Tools\Utility\FrozenTime']],
+			'Time' => ['class' => 'Tools.Time', 'config' => ['engine' => 'Tools\Utility\FrozenTime']],
 			'Tools.Format',
 			'Tools.Text',
 			'Shim.Configure',

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -11,7 +11,7 @@ trait LoadHelperTrait {
 	 */
 	protected function loadHelpers(): void {
 		$helpers = [
-			'Time' => ['class' => 'Tools.Time', 'engine' => 'Tools\Utility\FrozenTime'],
+			'Time' => ['config' => ['class' => 'Tools.Time', 'engine' => 'Tools\Utility\FrozenTime']],
 			'Tools.Format',
 			'Tools.Text',
 			'Shim.Configure',


### PR DESCRIPTION
On pages like the QueuedJobs overview there is a new deprecation warning.
![image](https://user-images.githubusercontent.com/9105243/141491962-a0992a21-6fae-4595-93e4-ad8d23e33b16.png)

Unfortunately this message first leads to a core issue but it actually is related to this plugin.

As seen in the code changed the config for the Tools Helper is not set correctly.

Therefore the Tools.Time Helper is loaded with its default config which is currently the deprecated Time Helper.
Therefore this warning is being shown.

Don't know if we need to adjust the array for older CakePHP versions but I hope the tests will show some more info 😄 