### PR TITLE
Don't pass arrays to is_dir()

### DIFF
--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -156,6 +156,9 @@ use Cake\Core\Configure;
 				} elseif (is_bool($configuration)) {
 					$configuration = $configuration ? 'true' : 'false';
 				}
+                if (is_array($configuration)) {
+                    $configuration = implode(', ', $configuration);
+                }
 				echo h($key) . ': ' . h($configuration);
 				echo '</li>';
 			}

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -155,8 +155,7 @@ use Cake\Core\Configure;
 					$configuration = str_replace(DS, '/', $configuration);
 				} elseif (is_bool($configuration)) {
 					$configuration = $configuration ? 'true' : 'false';
-				}
-                if (is_array($configuration)) {
+				} elseif (is_array($configuration)) {
                     $configuration = implode(', ', $configuration);
                 }
 				echo h($key) . ': ' . h($configuration);

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -150,7 +150,7 @@ use Cake\Core\Configure;
 
 			foreach ($configurations as $key => $configuration) {
 				echo '<li>';
-				if (is_dir($configuration)) {
+				if (is_string($configuration) && is_dir($configuration)) {
 					$configuration = str_replace(ROOT . DS, 'ROOT' . DS, $configuration);
 					$configuration = str_replace(DS, '/', $configuration);
 				} elseif (is_bool($configuration)) {


### PR DESCRIPTION
The [default config file](https://github.com/dereuromark/cakephp-queue/blob/master/config/app_queue.php) contains the settings `plugins` and `ignoredTasks` which are arrays. 

The rendering of the edited template fails because arrays must not be passed to `is_dir()`.