### PR TITLE
fix deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.3', '8.1']
+        php-version: ['7.4', '8.1']
         db-type: ['sqlite', 'mysql', 'pgsql']
         prefer-lowest: ['']
         include:
-          - php-version: '7.3'
+          - php-version: '7.4'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 

--- a/composer.json
+++ b/composer.json
@@ -23,18 +23,19 @@
 		}
 	],
 	"require": {
-		"php": ">=7.3",
+		"php": ">=7.4",
 		"cakephp/cakephp": "^4.2.0"
 	},
 	"require-dev": {
+		"cakedc/cakephp-phpstan": "^2.0",
 		"cakephp/bake": "^2.5.0",
 		"cakephp/migrations": "^3.0.0",
-		"friendsofcake/search": "^6.0.0",
-		"dereuromark/cakephp-tools": "^2.4.0",
-		"dereuromark/cakephp-ide-helper": "^1.0.0",
 		"cakephp/plugin-installer": "^1.3",
-		"phpunit/phpunit": "^9.5",
-		"fig-r/psr2r-sniffer": "dev-master"
+		"dereuromark/cakephp-ide-helper": "^1.0.0",
+		"dereuromark/cakephp-tools": "^2.4.0",
+		"fig-r/psr2r-sniffer": "dev-master",
+		"friendsofcake/search": "^6.0.0",
+		"phpunit/phpunit": "^9.5"
 	},
 	"suggest": {
 		"friendsofcake/search": "For admin backend and filtering of current jobs.",
@@ -61,7 +62,7 @@
 	"scripts": {
 		"stan": "phpstan analyse",
 		"stan-tests": "phpstan analyse -c tests/phpstan.neon",
-		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.0.0 && mv composer.backup composer.json",
+		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5.0 && mv composer.backup composer.json",
 		"test": "phpunit",
 		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml",
 		"lowest": "validate-prefer-lowest",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"cakephp/cakephp": "^4.2.0"
+		"cakephp/cakephp": "^4.3.0"
 	},
 	"require-dev": {
 		"cakedc/cakephp-phpstan": "^2.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,6 @@ parameters:
 		- '#Parameter \#1 \$.+ of function call_user_func_array expects .+, array.+ given.#'
 		- '#Cannot cast array\|string\|null to .+.#'
 		- '#Cannot cast non-empty-array\|non-empty-string to string#'
+
+includes:
+	- vendor/cakedc/cakephp-phpstan/extension.neon

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -79,7 +79,7 @@ class InfoCommand extends Command {
 		$io->out();
 
 		$io->out('Total unfinished jobs: ' . $this->QueuedJobs->getLength());
-		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
+		$this->QueueProcesses = $this->getTableLocator()->get('Queue.QueueProcesses');
 		$status = $this->QueueProcesses->status();
 		$io->out('Current running workers: ' . ($status ? $status['workers'] : '-'));
 		$io->out('Last run: ' . ($status ? $status['time']->nice() : '-'));

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -79,7 +79,7 @@ class InfoCommand extends Command {
 		$io->out();
 
 		$io->out('Total unfinished jobs: ' . $this->QueuedJobs->getLength());
-		$this->loadModel('Queue.QueueProcesses');
+		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
 		$status = $this->QueueProcesses->status();
 		$io->out('Current running workers: ' . ($status ? $status['workers'] : '-'));
 		$io->out('Last run: ' . ($status ? $status['time']->nice() : '-'));

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -36,7 +36,7 @@ class QueueController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function index() {
-		$this->loadModel('Queue.QueueProcesses');
+		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
 		$status = $this->QueueProcesses->status();
 
 		$current = $this->QueuedJobs->getLength();
@@ -128,7 +128,7 @@ class QueueController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function processes() {
-		$this->loadModel('Queue.QueueProcesses');
+		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
 
 		if ($this->request->is('post') && $this->request->getQuery('end')) {
 			$pid = (string)$this->request->getQuery('end');

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -9,7 +9,7 @@ use Exception;
 /**
  * @property \Queue\Model\Table\QueueProcessesTable $QueueProcesses
  *
- * @method \Queue\Model\Entity\QueueProcess[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess> paginate($object = null, array $settings = [])
  * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
  */
 class QueueProcessesController extends AppController {

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -14,7 +14,7 @@ use RuntimeException;
 /**
  * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
  *
- * @method \Queue\Model\Entity\QueuedJob[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob> paginate($object = null, array $settings = [])
  * @property \Search\Controller\Component\SearchComponent $Search
  */
 class QueuedJobsController extends AppController {

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -38,7 +38,7 @@ class OldTaskFinder {
 		$res = glob($path . '*Task.php');
 
 		$tasks = [];
-		if($res) {
+		if($res !== false) {
 			foreach ($res as $r) {
 				$name = basename($r, 'Task.php');
 				$name = substr($name, 5);

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -38,7 +38,7 @@ class OldTaskFinder {
 		$res = glob($path . '*Task.php');
 
 		$tasks = [];
-		if($res !== false) {
+		if($res) {
 			foreach ($res as $r) {
 				$name = basename($r, 'Task.php');
 				$name = substr($name, 5);

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -35,17 +35,15 @@ class OldTaskFinder {
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin) {
-		$res = glob($path . '*Task.php');
+		$res = glob($path . '*Task.php') ?: [];
 
 		$tasks = [];
-		if ($res) {
-			foreach ($res as $r) {
-				$name = basename($r, 'Task.php');
-				$name = substr($name, 5);
+		foreach ($res as $r) {
+			$name = basename($r, 'Task.php');
+			$name = substr($name, 5);
 
-				$taskKey = $plugin ? $plugin . '.' . $name : $name;
-				$tasks[$taskKey] = $path . $r;
-			}
+			$taskKey = $plugin ? $plugin . '.' . $name : $name;
+			$tasks[$taskKey] = $path . $r;
 		}
 
 		return $tasks;

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -3,7 +3,6 @@
 namespace Queue\Migration;
 
 use Cake\Core\App;
-use Cake\Filesystem\Folder;
 
 class OldTaskFinder {
 
@@ -36,16 +35,17 @@ class OldTaskFinder {
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin) {
-		$Folder = new Folder($path);
-		$res = $Folder->find('Queue.+Task\.php');
+		$res = glob($path . '*Task.php');
 
 		$tasks = [];
-		foreach ($res as $key => $r) {
-			$name = basename($r, 'Task.php');
-			$name = substr($name, 5);
+		if($res) {
+			foreach ($res as $r) {
+				$name = basename($r, 'Task.php');
+				$name = substr($name, 5);
 
-			$taskKey = $plugin ? $plugin . '.' . $name : $name;
-			$tasks[$taskKey] = $path . $r;
+				$taskKey = $plugin ? $plugin . '.' . $name : $name;
+				$tasks[$taskKey] = $path . $r;
+			}
 		}
 
 		return $tasks;

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -38,7 +38,7 @@ class OldTaskFinder {
 		$res = glob($path . '*Task.php');
 
 		$tasks = [];
-		if($res) {
+		if ($res) {
 			foreach ($res as $r) {
 				$name = basename($r, 'Task.php');
 				$name = substr($name, 5);

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -24,10 +24,10 @@ use Queue\Queue\Config;
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @method \Queue\Model\Entity\QueueProcess saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \Queue\Model\Entity\QueueProcess newEmptyEntity()
- * @method \Queue\Model\Entity\QueueProcess[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueueProcess[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueueProcess[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueueProcess[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess>|false saveMany(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess> saveManyOrFail(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess>|false deleteMany(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess> deleteManyOrFail(iterable $entities, $options = [])
  */
 class QueueProcessesTable extends Table {
 

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -32,10 +32,10 @@ use RuntimeException;
  * @mixin \Search\Model\Behavior\SearchBehavior
  * @property \Queue\Model\Table\QueueProcessesTable&\Cake\ORM\Association\BelongsTo $WorkerProcesses
  * @method \Queue\Model\Entity\QueuedJob newEmptyEntity()
- * @method \Queue\Model\Entity\QueuedJob[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueuedJob[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueuedJob[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \Queue\Model\Entity\QueuedJob[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob>|false saveMany(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob> saveManyOrFail(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob>|false deleteMany(iterable $entities, $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob> deleteManyOrFail(iterable $entities, $options = [])
  */
 class QueuedJobsTable extends Table {
 

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -5,8 +5,8 @@ namespace Queue\Queue;
 use Cake\Console\CommandInterface;
 use Cake\Core\Configure;
 use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\ORM\Exception\PersistenceFailedException;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Text;
 use Psr\Log\LoggerInterface;
 use Queue\Console\Io;
@@ -26,7 +26,7 @@ declare(ticks = 1);
  */
 class Processor {
 
-	use ModelAwareTrait;
+	use LocatorAwareTrait;
 
 	/**
 	 * @var \Queue\Console\Io
@@ -66,9 +66,8 @@ class Processor {
 		$this->io = $io;
 		$this->logger = $logger;
 
-		$this->modelClass = 'Queue.QueuedJobs';
-		$this->loadModel();
-		$this->loadModel('Queue.QueueProcesses');
+		$this->QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
+		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
 	}
 
 	/**

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -66,8 +66,9 @@ class Processor {
 		$this->io = $io;
 		$this->logger = $logger;
 
-		$this->QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
-		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
+		$tableLocator = $this->getTableLocator();
+		$this->QueuedJobs = $tableLocator->get('Queue.QueuedJobs');
+		$this->QueueProcesses = $tableLocator->get('Queue.QueueProcesses');
 	}
 
 	/**

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -7,7 +7,7 @@
 namespace Queue\Queue;
 
 use Cake\Console\ConsoleIo;
-use Cake\Datasource\ModelAwareTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Psr\Log\LoggerInterface;
 use Queue\Console\Io;
 
@@ -19,7 +19,7 @@ use Queue\Console\Io;
  */
 abstract class Task implements TaskInterface {
 
-	use ModelAwareTrait;
+	use LocatorAwareTrait;
 
 	/**
 	 * @var string
@@ -95,9 +95,9 @@ abstract class Task implements TaskInterface {
 		$this->io = $io ?: new Io(new ConsoleIo());
 		$this->logger = $logger;
 
-		$this->loadModel($this->queueModelClass);
+		$this->QueuedJobs = $this->fetchTable($this->queueModelClass);
 		if (isset($this->modelClass)) {
-			$this->loadModel();
+			$this->QueuedJobs = $this->fetchTable($this->modelClass);
 		}
 	}
 

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -95,9 +95,10 @@ abstract class Task implements TaskInterface {
 		$this->io = $io ?: new Io(new ConsoleIo());
 		$this->logger = $logger;
 
-		$this->QueuedJobs = $this->fetchTable($this->queueModelClass);
+		$tableLocator = $this->getTableLocator();
+		$this->QueuedJobs = $tableLocator->get($this->queueModelClass);
 		if (isset($this->modelClass)) {
-			$this->QueuedJobs = $this->fetchTable($this->modelClass);
+			$this->QueuedJobs = $tableLocator->get($this->modelClass);
 		}
 	}
 

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -96,10 +96,14 @@ abstract class Task implements TaskInterface {
 		$this->logger = $logger;
 
 		$tableLocator = $this->getTableLocator();
-		$this->QueuedJobs = $tableLocator->get($this->queueModelClass);
+
+		/** @var \Queue\Model\Table\QueuedJobsTable $QueuedJobs */
+		$QueuedJobs = $tableLocator->get($this->queueModelClass);
 		if (isset($this->modelClass)) {
-			$this->QueuedJobs = $tableLocator->get($this->modelClass);
+			/** @var \Queue\Model\Table\QueuedJobsTable $QueuedJobs */
+			$QueuedJobs = $tableLocator->get($this->modelClass);
 		}
+		$this->QueuedJobs = $QueuedJobs;
 	}
 
 	/**

--- a/src/Queue/Task/ExecuteTask.php
+++ b/src/Queue/Task/ExecuteTask.php
@@ -107,7 +107,7 @@ class ExecuteTask extends Task implements AddInterface {
 		$this->io->out($output);
 
 		if ($data['log']) {
-			$this->loadModel('Queue.QueueProcesses');
+			$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
 			$server = $this->QueueProcesses->buildServerString();
 			$this->log($server . ': `' . $command . '` exits with `' . $exitCode . '` and returns `' . print_r($output, true) . '`' . PHP_EOL . 'Data : ' . print_r($data, true), 'info');
 		}

--- a/src/Queue/Task/ExecuteTask.php
+++ b/src/Queue/Task/ExecuteTask.php
@@ -107,7 +107,7 @@ class ExecuteTask extends Task implements AddInterface {
 		$this->io->out($output);
 
 		if ($data['log']) {
-			$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
+			$this->QueueProcesses = $this->getTableLocator()->get('Queue.QueueProcesses');
 			$server = $this->QueueProcesses->buildServerString();
 			$this->log($server . ': `' . $command . '` exits with `' . $exitCode . '` and returns `' . print_r($output, true) . '`' . PHP_EOL . 'Data : ' . print_r($data, true), 'info');
 		}

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -77,7 +77,7 @@ class TaskFinder {
 		$tasks = [];
 		$ignoredTasks = Config::ignoredTasks();
 		$files = glob($path . '*Task.php');
-		if($files){
+		if($files !== false){
 			foreach ($files as $file) {
 				$name = basename($file, 'Task.php');
 				$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -5,7 +5,6 @@ namespace Queue\Queue;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Filesystem\Folder;
 use InvalidArgumentException;
 
 class TaskFinder {
@@ -75,21 +74,21 @@ class TaskFinder {
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin = null): array {
-		$Folder = new Folder($path);
-
 		$tasks = [];
 		$ignoredTasks = Config::ignoredTasks();
-		$files = $Folder->find('.+Task\.php');
-		foreach ($files as $file) {
-			$name = basename($file, 'Task.php');
-			$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');
+		$files = glob($path . '*Task.php');
+		if($files){
+			foreach ($files as $file) {
+				$name = basename($file, 'Task.php');
+				$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');
 
-			/** @phpstan-var class-string<\Queue\Queue\Task> $className */
-			$className = $namespace . '\Queue\Task\\' . $name . 'Task';
-			$key = $plugin ? $plugin . '.' . $name : $name;
+				/** @phpstan-var class-string<\Queue\Queue\Task> $className */
+				$className = $namespace . '\Queue\Task\\' . $name . 'Task';
+				$key = $plugin ? $plugin . '.' . $name : $name;
 
-			if (!in_array($className, $ignoredTasks, true)) {
-				$tasks[$key] = $className;
+				if (!in_array($className, $ignoredTasks, true)) {
+					$tasks[$key] = $className;
+				}
 			}
 		}
 

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -76,19 +76,17 @@ class TaskFinder {
 	protected function getTasks(string $path, ?string $plugin = null): array {
 		$tasks = [];
 		$ignoredTasks = Config::ignoredTasks();
-		$files = glob($path . '*Task.php');
-		if ($files) {
-			foreach ($files as $file) {
-				$name = basename($file, 'Task.php');
-				$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');
+		$files = glob($path . '*Task.php') ?: [];
+		foreach ($files as $file) {
+			$name = basename($file, 'Task.php');
+			$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');
 
-				/** @phpstan-var class-string<\Queue\Queue\Task> $className */
-				$className = $namespace . '\Queue\Task\\' . $name . 'Task';
-				$key = $plugin ? $plugin . '.' . $name : $name;
+			/** @phpstan-var class-string<\Queue\Queue\Task> $className */
+			$className = $namespace . '\Queue\Task\\' . $name . 'Task';
+			$key = $plugin ? $plugin . '.' . $name : $name;
 
-				if (!in_array($className, $ignoredTasks, true)) {
-					$tasks[$key] = $className;
-				}
+			if (!in_array($className, $ignoredTasks, true)) {
+				$tasks[$key] = $className;
 			}
 		}
 

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -77,7 +77,7 @@ class TaskFinder {
 		$tasks = [];
 		$ignoredTasks = Config::ignoredTasks();
 		$files = glob($path . '*Task.php');
-		if($files !== false){
+		if($files){
 			foreach ($files as $file) {
 				$name = basename($file, 'Task.php');
 				$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -77,7 +77,7 @@ class TaskFinder {
 		$tasks = [];
 		$ignoredTasks = Config::ignoredTasks();
 		$files = glob($path . '*Task.php');
-		if($files){
+		if ($files) {
 			foreach ($files as $file) {
 				$name = basename($file, 'Task.php');
 				$namespace = $plugin ? str_replace('/', '\\', $plugin) : Configure::read('App.namespace');

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -4,9 +4,9 @@ namespace Queue\View\Helper;
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\Number;
+use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\View\Helper;
 use Queue\Model\Entity\QueuedJob;
 
@@ -16,7 +16,7 @@ use Queue\Model\Entity\QueuedJob;
  */
 class QueueProgressHelper extends Helper {
 
-	use ModelAwareTrait;
+	use LocatorAwareTrait;
 
 	/**
 	 * @var array<mixed>
@@ -225,7 +225,7 @@ class QueueProgressHelper extends Helper {
 			$queuedJobStatistics = Cache::read(static::KEY, static::CONFIG);
 		}
 		if ($queuedJobStatistics === false) {
-			$this->loadModel('Queue.QueuedJobs');
+			$this->QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
 			$queuedJobStatistics = $this->QueuedJobs->getStats(true);
 			Cache::write(static::KEY, $queuedJobStatistics, static::CONFIG);
 		}

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -225,7 +225,7 @@ class QueueProgressHelper extends Helper {
 			$queuedJobStatistics = Cache::read(static::KEY, static::CONFIG);
 		}
 		if ($queuedJobStatistics === false) {
-			$this->QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
+			$this->QueuedJobs = $this->getTableLocator()->get('Queue.QueuedJobs');
 			$queuedJobStatistics = $this->QueuedJobs->getStats(true);
 			Cache::write(static::KEY, $queuedJobStatistics, static::CONFIG);
 		}


### PR DESCRIPTION
Fixes #325

BUT there is still a problem which I can't really get my head around.

Its about the new `->fetchTable()` method from the `LocatorAwareTrait` not returning the "correct" types even though https://github.com/CakeDC/cakephp-phpstan is installed.

I was able to easily replace the deprecated `Cake\Filesystem\Folder` class usages with just some plain old `glob()` functions. No need for SPL classes.

The changes in the `composer.json` are just my editor re-ordering the packages alphabatically. If this is a problem I can for sure just return that to its original state (and I declared to use phpstan 1.5 and requiring PHP 7.4)