### PR TITLE
fix exception error on phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
 	"scripts": {
 		"stan": "phpstan analyse",
 		"stan-tests": "phpstan analyse -c tests/phpstan.neon",
-		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5.0 && mv composer.backup composer.json",
+		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.7.0 && mv composer.backup composer.json",
 		"test": "phpunit",
 		"test-coverage": "phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml",
 		"lowest": "validate-prefer-lowest",

--- a/src/Model/ProcessEndingException.php
+++ b/src/Model/ProcessEndingException.php
@@ -2,7 +2,7 @@
 
 namespace Queue\Model;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
-class ProcessEndingException extends Exception {
+class ProcessEndingException extends CakeException {
 }


### PR DESCRIPTION
Seems like PHPStan doesn't understand the alias we are setting via
```
class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');
```
So I used the new exception class now.