### PR TITLE
PHP 82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           then
             composer update --prefer-lowest --prefer-stable
           else
-            composer install --no-progress --prefer-dist --optimize-autoloader
+            composer install --no-progress --prefer-dist --optimize-autoloader --ignore-platform-req=php
           fi
           if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then composer lowest-setup; fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.1']
+        php-version: ['7.4', '8.2']
         db-type: ['sqlite', 'mysql', 'pgsql']
         prefer-lowest: ['']
         include:

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -22,9 +22,6 @@ declare(ticks = 1);
 
 /**
  * Main shell to init and run queue workers.
- *
- * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
- * @property \Queue\Model\Table\QueueProcessesTable $QueueProcesses
  */
 class Processor {
 
@@ -69,6 +66,16 @@ class Processor {
 	 * @var string|null
 	 */
 	protected $pid;
+
+	/**
+	 * @var \Queue\Model\Table\QueuedJobsTable
+	 */
+	protected $QueuedJobs;
+
+	/**
+	 * @var \Queue\Model\Table\QueueProcessesTable
+	 */
+	protected $QueueProcesses;
 
 	/**
 	 * @param \Queue\Console\Io $io


### PR DESCRIPTION
Given that we now removed the ModelAwareTrait we could probably make the library 8.2+ compatible 

> Deprecated: Creation of dynamic property Queue\Controller\Admin\QueueProcessesController::$Flash is deprecated in /.../vendor/cakephp/cakephp/src/Controller/Controller.php on line 362

Those could be fixed using non dynamic props.

cc @LordSimal 

See https://github.com/dereuromark/cakephp-queue/runs/6726720243?check_suite_focus=true#step:11:392