### PR TITLE
add random number to workerkey generation

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -906,7 +906,7 @@ class QueuedJobsTable extends Table {
 		if ($this->_key !== null) {
 			return $this->_key;
 		}
-		$this->_key = sha1(microtime());
+		$this->_key = sha1(microtime() . rand(100, 999));
 		if (!$this->_key) {
 			throw new RuntimeException('Invalid key generated');
 		}

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -906,7 +906,7 @@ class QueuedJobsTable extends Table {
 		if ($this->_key !== null) {
 			return $this->_key;
 		}
-		$this->_key = sha1(microtime() . rand(100, 999));
+		$this->_key = sha1(microtime() . mt_rand(100, 999));
 		if (!$this->_key) {
 			throw new RuntimeException('Invalid key generated');
 		}


### PR DESCRIPTION
Sometimes we get random SQL errors like this one when running the queue worker:
```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '35a454c17942a60acb27fb20fccb3cce8e1b70b0' for key 'workerkey'
```

seems like under certain (unknown) circumstances the generated workerkey name is not unique because `microtime()` seems to return the same value for different workers.

This fix should at least reduce the chance of generating exactly the same workerkey.