### PR TITLE
CakePHP 2.x - Don't cache queries for QueuedTasks

### DIFF
--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -11,6 +11,8 @@ App::uses('Hash', 'Utility');
  */
 class QueuedTask extends QueueAppModel {
 
+	public $cacheQueries = false;
+
 	public $_next_priority = 5;
 
 	public $rateHistory = [];


### PR DESCRIPTION
I've spent the last day troubleshooting an odd issue with the CakePHP 2.x version of this library. I eventually tracked it down to the following query returning records that were updated in the previous run:

```
                // Read which one actually got updated, which is the job we are supposed to execute.
		$data = $this->find('first', [
			'conditions' => [
				'workerkey' => $key,
				'completed' => null,
			],
			'order' => ['fetched' => 'DESC']
		]);
```

Disabling queryCache for the worker resolves this issue. I realise it's an old version but thought I'd offer the PR anyway.

Thanks,

Ben