### PR TITLE
cake5 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"cakephp/cakephp": "5.x-dev"
 	},
 	"require-dev": {
-		"cakedc/cakephp-phpstan": "dev-patch-1",
+		"cakedc/cakephp-phpstan": "dev-3.next-cake5",
 		"cakephp/bake": "3.x-dev",
 		"cakephp/migrations": "4.x-dev",
 		"cakephp/plugin-installer": "^1.3",
@@ -59,12 +59,6 @@
 			"Foo\\": "tests/test_app/plugins/Foo/src/"
 		}
 	},
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/dereuromark/cakephp-phpstan.git"
-		}
-	],
 	"prefer-stable": true,
 	"scripts": {
 		"stan": "phpstan analyse",

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
  * This file configures default behavior for all workers
  *
  * To modify these parameters, copy this file into your own CakePHP config directory or copy the array into your existing file.
  */
+use Tools\View\Icon\BootstrapIcon;
 
 return [
 	'Queue' => [
@@ -72,7 +74,7 @@ return [
 	],
 	'Icon' => [
 		'sets' => [
-			'bs' => \Tools\View\Icon\BootstrapIcon::class,
+			'bs' => BootstrapIcon::class,
 		],
 	],
 ];

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -10,16 +10,12 @@ use Cake\Core\Configure;
 use Cake\I18n\Number;
 use Queue\Queue\TaskFinder;
 
-/**
- * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
- * @property \Queue\Model\Table\QueueProcessesTable $QueueProcesses
- */
 class InfoCommand extends Command {
 
 	/**
-	 * @var string
+	 * @var string|null
 	 */
-	protected ?string $defaultTable =  'Queue.QueuedJobs';
+	protected ?string $defaultTable = 'Queue.QueuedJobs';
 
 	/**
 	 * @inheritDoc
@@ -78,8 +74,10 @@ class InfoCommand extends Command {
 		$io->hr();
 		$io->out();
 
-		$io->out('Total unfinished jobs: ' . $this->QueuedJobs->getLength());
+		$QueuedJobs = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$QueueProcesses = $this->getTableLocator()->get('Queue.QueueProcesses');
+
+		$io->out('Total unfinished jobs: ' . $QueuedJobs->getLength());
 		$status = $QueueProcesses->status();
 		$io->out('Current running workers: ' . ($status ? $status['workers'] : '-'));
 		$io->out('Last run: ' . ($status ? $status['time']->nice() : '-'));
@@ -90,10 +88,10 @@ class InfoCommand extends Command {
 		$io->out();
 
 		$io->out('Jobs currently in the queue:');
-		$types = $this->QueuedJobs->getTypes()->toArray();
+		$types = $QueuedJobs->getTypes()->toArray();
 		//TODO: refactor using $io->helper table?
 		foreach ($types as $type) {
-			$io->out(' - ' . str_pad($type, 20, ' ', STR_PAD_RIGHT) . ': ' . $this->QueuedJobs->getLength($type));
+			$io->out(' - ' . str_pad($type, 20, ' ', STR_PAD_RIGHT) . ': ' . $QueuedJobs->getLength($type));
 		}
 
 		$io->out();
@@ -101,7 +99,7 @@ class InfoCommand extends Command {
 		$io->out();
 
 		$io->out('Finished job statistics:');
-		$data = $this->QueuedJobs->getStats();
+		$data = $QueuedJobs->getStats();
 		//TODO: refactor using $io->helper table?
 		foreach ($data as $item) {
 			$io->out(' - ' . $item['job_task'] . ': ');

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -10,6 +10,7 @@ use Cake\Core\Configure;
 use Cake\Error\Debugger;
 use Cake\I18n\DateTime;
 use Queue\Model\Entity\QueuedJob;
+use Queue\Model\Table\QueuedJobsTable;
 use Queue\Utility\Serializer;
 
 /**
@@ -17,14 +18,23 @@ use Queue\Utility\Serializer;
  */
 class JobCommand extends Command {
 
-	/**
-	 * @var string
-	 */
-	protected ?string $defaultTable =  'Queue.QueuedJobs';
+	protected QueuedJobsTable $QueuedJobs;
 
 	/**
-	 * @inheritDoc
+	 * @var string|null
 	 */
+	protected ?string $defaultTable = 'Queue.QueuedJobs';
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		$this->QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
+	}
+
+	/**
+	   * @inheritDoc
+	   */
 	public static function defaultName(): string {
 		return 'queue job';
 	}

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -8,6 +8,7 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
+use Queue\Model\Table\QueueProcessesTable;
 use Queue\Queue\Config;
 
 /**
@@ -15,14 +16,23 @@ use Queue\Queue\Config;
  */
 class WorkerCommand extends Command {
 
-	/**
-	 * @var string
-	 */
-	protected ?string $defaultTable =  'Queue.QueueProcesses';
+	protected QueueProcessesTable $QueueProcesses;
 
 	/**
-	 * @inheritDoc
+	 * @var string|null
 	 */
+	protected ?string $defaultTable = 'Queue.QueueProcesses';
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		$this->QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
+	}
+
+	/**
+	   * @inheritDoc
+	   */
 	public static function defaultName(): string {
 		return 'queue job';
 	}

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -40,7 +40,7 @@ class QueueProcessesController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function index() {
-		$queueProcesses = $this->paginate()->toArray();
+		$queueProcesses = $this->paginate();
 
 		$this->set(compact('queueProcesses'));
 	}

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -7,6 +7,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Http\Exception\NotFoundException;
 use Cake\I18n\DateTime;
+use Cake\View\JsonView;
 use Laminas\Diactoros\UploadedFile;
 use Queue\Queue\TaskFinder;
 use RuntimeException;
@@ -114,10 +115,17 @@ class QueuedJobsController extends AppController {
 	}
 
 	/**
-	 * @throws \RuntimeException
-	 *
-	 * @return \Cake\Http\Response|null|void
+	 * @return array<string>
 	 */
+	public function viewClasses(): array {
+		return [JsonView::class];
+	}
+
+	/**
+	   * @throws \RuntimeException
+	   *
+	   * @return \Cake\Http\Response|null|void
+	   */
 	public function import() {
 		if ($this->request->is(['post'])) {
 			/** @var \Laminas\Diactoros\UploadedFile|array<string, mixed> $file */

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -560,8 +560,7 @@ class QueuedJobsTable extends Table {
 
 		// Generate the task specific conditions.
 		foreach ($tasks as $name => $task) {
-			/** @var \Cake\I18n\DateTime $timeoutAt */
-			$timeoutAt = $now->copy();
+			$timeoutAt = clone $now;
 			$tmp = [
 				'job_task' => $name,
 				'AND' => [
@@ -882,7 +881,7 @@ class QueuedJobsTable extends Table {
 	 */
 	public function clearDoublettes(): void {
 		/** @var array<int> $x */
-		$x = $this->getConnection()->query('SELECT max(id) as id FROM `' . $this->getTable() . '`
+		$x = $this->getConnection()->selectQuery('SELECT max(id) as id FROM `' . $this->getTable() . '`
 	WHERE completed is NULL
 	GROUP BY data
 	HAVING COUNT(id) > 1');

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -3,11 +3,13 @@
 namespace Queue\Test\TestCase\Controller\Admin;
 
 use Cake\Datasource\ConnectionManager;
+use Cake\Http\ServerRequest;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
 use Queue\Controller\Admin\QueueController;
 use Shim\TestSuite\TestCase;
 use Shim\TestSuite\TestTrait;
+use Tools\Utility\DateTime as ToolsDateTime;
 
 //use Tools\Utility\DateTime as ToolsDateTime;
 
@@ -42,13 +44,12 @@ class QueueControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testLoadHelpers(): void {
-		$controller = new QueueController();
+		$controller = new QueueController(new ServerRequest(['url' => 'controller/posts/index']));
 		$this->invokeMethod($controller, 'loadHelpers');
 
 		$view = $controller->createView();
 		$engine = $view->Time->getConfig('engine');
-		dd($engine);
-		//$this->assertTrue(in_array($engine, [DateTime::class, ToolsDateTime::class], true));
+		$this->assertTrue(in_array($engine, [DateTime::class, ToolsDateTime::class], true));
 	}
 
 	/**
@@ -245,7 +246,7 @@ class QueueControllerTest extends TestCase {
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
 			'failed' => 1,
-			'fetched' => (new DateTime())->subHour(),
+			'fetched' => (new DateTime())->subHours(1),
 		]);
 		$jobsTable->saveOrFail($job);
 

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -154,7 +154,8 @@ class QueuedJobsControllerTest extends TestCase {
 	public function testViewJson() {
 		$queuedJob = $this->createJob();
 
-		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id, '_ext' => 'json']);
+		$this->requestAsJson();
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id]);
 
 		$this->assertResponseCode(200);
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -689,9 +689,9 @@ class QueuedJobsTableTest extends TestCase {
 	public function testGetStats() {
 		$queuedJob = $this->QueuedJobs->newEntity([
 			'job_task' => 'Foo',
-			'completed' => (new DateTime())->subHour(2),
-			'fetched' => (new DateTime())->subHour(3),
-			'created' => (new DateTime())->subHour(5),
+			'completed' => (new DateTime())->subHours(2),
+			'fetched' => (new DateTime())->subHours(3),
+			'created' => (new DateTime())->subHours(5),
 		]);
 		$this->QueuedJobs->saveOrFail($queuedJob);
 

--- a/tests/TestCase/Queue/TaskFinderTest.php
+++ b/tests/TestCase/Queue/TaskFinderTest.php
@@ -47,11 +47,6 @@ class TaskFinderTest extends TestCase {
 
 		$result = $this->taskFinder->resolve(ExampleTask::taskName());
 		$this->assertSame('Queue.Example', $result);
-
-		$this->deprecated(function () {
-			$result = $this->taskFinder->resolve('Example');
-			$this->assertSame('Queue.Example', $result);
-		});
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -22,12 +22,12 @@ class QueueProgressHelperTest extends TestCase {
 	/**
 	 * @var \Queue\View\Helper\QueueProgressHelper
 	 */
-	protected $QueueProgressHelper;
+	protected QueueProgressHelper $QueueProgressHelper;
 
 	/**
 	 * @var string
 	 */
-	protected $locale;
+	protected string $locale;
 
 	/**
 	 * @return void
@@ -86,7 +86,7 @@ class QueueProgressHelperTest extends TestCase {
 	public function testProgressCalculatedEmpty() {
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
-			'fetched' => (new DateTime())->subMinute(),
+			'fetched' => (new DateTime())->subMinutes(1),
 		]);
 		$result = $this->QueueProgressHelper->progress($queuedJob);
 		$this->assertNull($result);
@@ -99,14 +99,14 @@ class QueueProgressHelperTest extends TestCase {
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
 			'created' => (new DateTime())->subMinutes(2),
-			'fetched' => (new DateTime())->subMinute(),
+			'fetched' => (new DateTime())->subMinutes(1),
 			'completed' => (new DateTime())->subSeconds(2),
 		]);
 		$this->getTableLocator()->get('Queue.QueuedJobs')->saveOrFail($queuedJob);
 
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
-			'fetched' => (new DateTime())->subMinute(),
+			'fetched' => (new DateTime())->subMinutes(1),
 		]);
 
 		$result = $this->QueueProgressHelper->progress($queuedJob);
@@ -160,14 +160,14 @@ class QueueProgressHelperTest extends TestCase {
 		/** @var \Queue\Model\Entity\QueuedJob $queuedJob */
 		$queuedJob = $this->getTableLocator()->get('Queue.QueuedJobs')->newEntity([
 			'job_task' => 'Foo',
-			'created' => (new DateTime())->subHour(),
-			'fetched' => (new DateTime())->subHour(),
-			'completed' => (new DateTime())->subHour()->addMinutes(10),
+			'created' => (new DateTime())->subHours(1),
+			'fetched' => (new DateTime())->subHours(1),
+			'completed' => (new DateTime())->subHours(1)->addMinutes(10),
 		]);
 		$this->getTableLocator()->get('Queue.QueuedJobs')->saveOrFail($queuedJob);
 
 		$queuedJob->completed = null;
-		$queuedJob->fetched = (new DateTime())->subMinute();
+		$queuedJob->fetched = (new DateTime())->subMinutes(1);
 
 		$result = $this->QueueProgressHelper->progressBar($queuedJob, 5);
 		$this->assertTextContains('<span title="10%">', $result);
@@ -178,8 +178,8 @@ class QueueProgressHelperTest extends TestCase {
 	 */
 	public function testTimeoutProgressBar() {
 		$queuedJob = new QueuedJob([
-			'created' => (new DateTime())->subHour(),
-			'notbefore' => (new DateTime())->addHour(),
+			'created' => (new DateTime())->subHours(1),
+			'notbefore' => (new DateTime())->addHours(1),
 		]);
 
 		$result = $this->QueueProgressHelper->timeoutProgressBar($queuedJob, 5);
@@ -191,8 +191,8 @@ class QueueProgressHelperTest extends TestCase {
 	 */
 	public function testHtmlTimeoutProgressBar() {
 		$queuedJob = new QueuedJob([
-			'created' => (new DateTime())->subMinute(),
-			'notbefore' => (new DateTime())->addMinute(),
+			'created' => (new DateTime())->subMinutes(1),
+			'notbefore' => (new DateTime())->addMinutes(1),
 		]);
 		$result = $this->QueueProgressHelper->htmlTimeoutProgressBar($queuedJob);
 		$expected = '<progress value="50" max="100" title="50%"></progress>';
@@ -200,7 +200,7 @@ class QueueProgressHelperTest extends TestCase {
 
 		$queuedJob = new QueuedJob([
 			'created' => (new DateTime()),
-			'notbefore' => (new DateTime())->addHour(),
+			'notbefore' => (new DateTime())->addHours(1),
 		]);
 		// For IE9 and below
 		$fallback = $this->QueueProgressHelper->timeoutProgressBar($queuedJob, 10);
@@ -209,8 +209,8 @@ class QueueProgressHelperTest extends TestCase {
 		$this->assertSame($expected, $result);
 
 		$queuedJob = new QueuedJob([
-			'created' => (new DateTime())->subMinute(),
-			'notbefore' => (new DateTime())->subSecond(),
+			'created' => (new DateTime())->subMinutes(1),
+			'notbefore' => (new DateTime())->subSeconds(1),
 		]);
 		// For IE9 and below
 		$fallback = $this->QueueProgressHelper->timeoutProgressBar($queuedJob, 10);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,11 @@
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Mailer\TransportFactory;
 use Shim\Filesystem\Folder;
+use Tools\View\Icon\BootstrapIcon;
 
 if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
@@ -48,7 +50,7 @@ Configure::write('App', [
 ]);
 Configure::write('Icon', [
 	'sets' => [
-		'bs' => \Tools\View\Icon\BootstrapIcon::class,
+		'bs' => BootstrapIcon::class,
 	],
 ]);
 
@@ -108,18 +110,6 @@ TransportFactory::setConfig('queue', [
 	'className' => 'Queue.Queue',
 ]);
 
-// Allow local overwrite
-// E.g. in your console: export DB_URL="mysql://root:secret@127.0.0.1/cake_test"
-if (getenv('DB_URL')) {
-	ConnectionManager::setConfig('test', [
-		'url' => getenv('DB_URL'),
-		'quoteIdentifiers' => false,
-		'cacheMetadata' => true,
-	]);
-
-	return;
-}
-
 if (!getenv('DB_CLASS')) {
 	putenv('DB_CLASS=Cake\Database\Driver\Sqlite');
 	putenv('DB_URL=sqlite:///:memory:');
@@ -127,7 +117,7 @@ if (!getenv('DB_CLASS')) {
 
 // Uses Travis config then (MySQL, Postgres, ...)
 ConnectionManager::setConfig('test', [
-	'className' => 'Cake\Database\Connection',
+	'className' => Connection::class,
 	'driver' => getenv('DB_CLASS') ?: null,
 	'dsn' => getenv('DB_URL') ?: null,
 	'timezone' => 'UTC',


### PR DESCRIPTION
I am not quite sure what the current state of the MailerTask is in this cake5 branch.
These tests fail because `$data['settings']` can either be a Mailer instance or a Message object so
```
$data['settings'] + $this->defaults
```
is not really valid.
Whats your suggestion?