### PR TITLE
Change "failed" column to "attempts"

### DIFF
--- a/config/Migrations/20230102000001_MigrationQueueReplaceFailedWithAttempted.php
+++ b/config/Migrations/20230102000001_MigrationQueueReplaceFailedWithAttempted.php
@@ -1,0 +1,24 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MigrationQueueReplaceFailedWithAttempted extends AbstractMigration {
+
+	/**
+	 * Change Method.
+	 *
+	 * Write your reversible migrations using this method.
+	 *
+	 * More information on writing migrations is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+	 *
+	 * @return void
+	 */
+	public function change() {
+		$this->table('queued_jobs')
+			->renameColumn('failed', 'attempts')
+			->update();
+		$this->query('UPDATE queued_jobs SET attempts = attempts + 1 WHERE completed IS NOT NULL');
+	}
+
+}

--- a/docs/sections/queueing_jobs.md
+++ b/docs/sections/queueing_jobs.md
@@ -280,7 +280,7 @@ You need to handle the content of this `$data` string manually inside your `add(
 You can add buttons to your specific app views to re-run a failed job, or to remove it.
 ```php
 $this->loadHelper('Queue.Queue');
-if ($this->Queue->failed($queuedJob)) {
+if ($this->Queue->hasFailed($queuedJob)) {
     $query = ['redirect' => $this->request->getAttribute('here')];
     echo $this->Form->postLink(
         'Re-Run job',

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -91,7 +91,7 @@ class JobCommand extends Command {
 			}
 
 			foreach ($jobs as $job) {
-				$io->out('- [' . $job->id . '] ' . $job->job_task . ' (' . ($job->completed ? 'completed' : 'failed ' . $job->attempts . 'x') . ')');
+				$io->out('- [' . $job->id . '] ' . $job->job_task . ' (' . ($job->completed ? 'completed' : 'attempted ' . $job->attempts . 'x') . ')');
 			}
 
 			return static::CODE_ERROR;

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -81,7 +81,7 @@ class JobCommand extends Command {
 
 			/** @var array<\Queue\Model\Entity\QueuedJob> $jobs */
 			$jobs = $this->QueuedJobs->find()
-				->select(['id', 'job_task', 'completed', 'failed'])
+				->select(['id', 'job_task', 'completed', 'attempts'])
 				->orderDesc('id')
 				->limit(20)->all()->toArray();
 			if ($jobs) {
@@ -91,7 +91,7 @@ class JobCommand extends Command {
 			}
 
 			foreach ($jobs as $job) {
-				$io->out('- [' . $job->id . '] ' . $job->job_task . ' (' . ($job->completed ? 'completed' : 'failed ' . $job->failed . 'x') . ')');
+				$io->out('- [' . $job->id . '] ' . $job->job_task . ' (' . ($job->completed ? 'completed' : 'failed ' . $job->attempts . 'x') . ')');
 			}
 
 			return static::CODE_ERROR;
@@ -252,9 +252,9 @@ class JobCommand extends Command {
 
 		$io->out('Completed: ' . ($queuedJob->completed ?: '-'));
 		if (!$queuedJob->completed) {
-			$io->out('Failed: ' . ($queuedJob->failed ?: '-'));
+			$io->out('Failed: ' . ($queuedJob->attempts ?: '-'));
 		}
-		if ($queuedJob->failed) {
+		if ($queuedJob->attempts) {
 			$io->out('Failure message: ' . ($queuedJob->failure_message ?: '-'));
 		}
 

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -44,7 +44,7 @@ class QueueController extends AppController {
 		$pendingDetails = $this->QueuedJobs->getPendingStats()->toArray();
 		$new = 0;
 		foreach ($pendingDetails as $pendingDetail) {
-			if ($pendingDetail['fetched'] || $pendingDetail['failed']) {
+			if ($pendingDetail['fetched'] || $pendingDetail['attempts']) {
 				continue;
 			}
 			$new++;

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -148,7 +148,7 @@ class QueuedJobsController extends AppController {
 					$data['fetched'] = null;
 					$data['completed'] = null;
 					$data['progress'] = null;
-					$data['failed'] = 0;
+					$data['attempts'] = 0;
 					$data['failure_message'] = null;
 					$data['workerkey'] = null;
 					$data['status'] = null;

--- a/src/Model/Entity/QueuedJob.php
+++ b/src/Model/Entity/QueuedJob.php
@@ -15,7 +15,7 @@ use Cake\ORM\Entity;
  * @property \Cake\I18n\DateTime|null $fetched
  * @property \Cake\I18n\DateTime|null $completed
  * @property float|null $progress
- * @property int $failed
+ * @property int $attempts
  * @property string|null $failure_message
  * @property string|null $workerkey
  * @property string|null $status

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -636,6 +636,7 @@ class QueuedJobsTable extends Table {
 				'fetched' => $now,
 				'progress' => null,
 				'failure_message' => null,
+				'attempts' => $job->attempts + 1,
 			]);
 
 			return $this->saveOrFail($job);
@@ -688,7 +689,7 @@ class QueuedJobsTable extends Table {
 	}
 
 	/**
-	 * Mark a job as Failed, incrementing the failed-counter and Requeueing it.
+	 * Mark a job as Failed, without incrementing the "attempts" count due to to it being incremented when fetched.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $job Job
 	 * @param string|null $failureMessage Optional message to append to the failure_message field.
@@ -696,7 +697,6 @@ class QueuedJobsTable extends Table {
 	 */
 	public function markJobFailed(QueuedJob $job, ?string $failureMessage = null): bool {
 		$fields = [
-			'attempts' => $job->attempts + 1,
 			'failure_message' => $failureMessage,
 		];
 		$job = $this->patchEntity($job, $fields);

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -577,7 +577,7 @@ class QueuedJobsTable extends Table {
 						],
 					],
 				],
-				'failed <' => ($task['retries'] + 1),
+				'attempts <' => ($task['retries'] + 1),
 			];
 			if (array_key_exists('rate', $task) && $tmp['job_task'] && array_key_exists($tmp['job_task'], $this->rateHistory)) {
 				switch ($driverName) {
@@ -696,7 +696,7 @@ class QueuedJobsTable extends Table {
 	 */
 	public function markJobFailed(QueuedJob $job, ?string $failureMessage = null): bool {
 		$fields = [
-			'failed' => $job->failed + 1,
+			'attempts' => $job->attempts + 1,
 			'failure_message' => $failureMessage,
 		];
 		$job = $this->patchEntity($job, $fields);
@@ -715,7 +715,7 @@ class QueuedJobsTable extends Table {
 
 		$conditions = [
 			'completed IS' => null,
-			'failed >' => 0,
+			'attempts >' => 0,
 			'fetched <' => $thresholdTime,
 		];
 
@@ -735,7 +735,7 @@ class QueuedJobsTable extends Table {
 			'completed' => null,
 			'fetched' => null,
 			'progress' => null,
-			'failed' => 0,
+			'attempts' => 0,
 			'workerkey' => null,
 			'failure_message' => null,
 		];
@@ -746,7 +746,7 @@ class QueuedJobsTable extends Table {
 			$conditions['id'] = $id;
 		}
 		if (!$full) {
-			$conditions['failed >'] = 0;
+			$conditions['attempts >'] = 0;
 		}
 
 		return $this->updateAll($fields, $conditions);
@@ -763,7 +763,7 @@ class QueuedJobsTable extends Table {
 			'completed' => null,
 			'fetched' => null,
 			'progress' => null,
-			'failed' => 0,
+			'attempts' => 0,
 			'workerkey' => null,
 			'failure_message' => null,
 		];
@@ -788,7 +788,7 @@ class QueuedJobsTable extends Table {
 			'completed' => null,
 			'fetched' => null,
 			'progress' => null,
-			'failed' => 0,
+			'attempts' => 0,
 			'workerkey' => null,
 			'failure_message' => null,
 		];
@@ -817,7 +817,7 @@ class QueuedJobsTable extends Table {
 				'progress',
 				'reference',
 				'notbefore',
-				'failed',
+				'attempts',
 				'failure_message',
 			],
 			'conditions' => [
@@ -856,7 +856,7 @@ class QueuedJobsTable extends Table {
 			return $failureMessageRequeued;
 		}
 		$retries = $taskConfiguration[$queuedTaskName]['retries'];
-		if ($queuedTask->failed <= $retries) {
+		if ($queuedTask->attempts <= $retries) {
 			return $failureMessageRequeued;
 		}
 

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -224,7 +224,7 @@ class Processor {
 			$this->QueuedJobs->markJobFailed($queuedJob, $failureMessage);
 			$failedStatus = $this->QueuedJobs->getFailedStatus($queuedJob, $this->getTaskConf());
 			$this->log('job ' . $queuedJob->job_task . ', id ' . $queuedJob->id . ' failed and ' . $failedStatus, $pid);
-			$this->io->out('Job did not finish, ' . $failedStatus . ' after try ' . $queuedJob->failed . '.');
+			$this->io->out('Job did not finish, ' . $failedStatus . ' after try ' . $queuedJob->attempts . '.');
 
 			return;
 		}

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -23,7 +23,7 @@ class QueueHelper extends Helper {
 	 * @return bool
 	 */
 	public function hasFailed(QueuedJob $queuedJob): bool {
-		if ($queuedJob->completed || !$queuedJob->fetched || !$queuedJob->failed) {
+		if ($queuedJob->completed || !$queuedJob->fetched || !$queuedJob->attempts) {
 			return false;
 		}
 
@@ -34,7 +34,7 @@ class QueueHelper extends Helper {
 
 		// Requeued
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-		if ($taskConfig && $queuedJob->failed <= $taskConfig['retries']) {
+		if ($taskConfig && $queuedJob->attempts <= $taskConfig['retries']) {
 			return false;
 		}
 
@@ -47,7 +47,9 @@ class QueueHelper extends Helper {
 	 * @return string|null
 	 */
 	public function fails(QueuedJob $queuedJob): ?string {
-		if (!$queuedJob->failed) {
+		$fails = $queuedJob->attempts - ($queuedJob->completed ? 1 : 0);
+
+		if ($fails < 1) {
 			return '0x';
 		}
 
@@ -55,10 +57,10 @@ class QueueHelper extends Helper {
 		if ($taskConfig) {
 			$allowedFails = $taskConfig['retries'] + 1;
 
-			return $queuedJob->failed . '/' . $allowedFails;
+			return $fails . '/' . $allowedFails;
 		}
 
-		return $queuedJob->failed . 'x';
+		return $fails . 'x';
 	}
 
 	/**
@@ -68,7 +70,7 @@ class QueueHelper extends Helper {
 	 * @return string|null
 	 */
 	public function failureStatus(QueuedJob $queuedJob): ?string {
-		if ($queuedJob->completed || !$queuedJob->fetched || !$queuedJob->failed) {
+		if ($queuedJob->completed || !$queuedJob->fetched || !$queuedJob->attempts) {
 			return null;
 		}
 
@@ -77,7 +79,7 @@ class QueueHelper extends Helper {
 		}
 
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-		if ($taskConfig && $queuedJob->failed <= $taskConfig['retries']) {
+		if ($taskConfig && $queuedJob->attempts <= $taskConfig['retries']) {
 			return __d('queue', 'Requeued');
 		}
 

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -46,21 +46,19 @@ class QueueHelper extends Helper {
 	 *
 	 * @return string|null
 	 */
-	public function fails(QueuedJob $queuedJob): ?string {
-		$fails = $queuedJob->attempts - ($queuedJob->completed ? 1 : 0);
-
-		if ($fails < 1) {
+	public function attempts(QueuedJob $queuedJob): ?string {
+		if ($queuedJob->attempts < 1) {
 			return '0x';
 		}
 
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
 		if ($taskConfig) {
-			$allowedFails = $taskConfig['retries'] + 1;
+			$maxFails = $taskConfig['retries'] + 1;
 
-			return $fails . '/' . $allowedFails;
+			return $queuedJob->attempts . '/' . $maxFails;
 		}
 
-		return $fails . 'x';
+		return $queuedJob->attempts . 'x';
 	}
 
 	/**

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -83,7 +83,7 @@ use Cake\Core\Configure;
 						$status = ' (' . __d('queue', 'status') . ': ' . h($pendingJob->status) . ')';
 					}
 
-					if (!$pendingJob->failed || !$pendingJob->failure_message) {
+					if (!$pendingJob->attempts || !$pendingJob->failure_message) {
 						echo '<li>';
 						echo __d('queue', 'Progress') . ': ';
 						echo $this->QueueProgress->progress($pendingJob) . $status;

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -83,7 +83,7 @@ use Cake\Core\Configure;
 						$status = ' (' . __d('queue', 'status') . ': ' . h($pendingJob->status) . ')';
 					}
 
-					if (!$pendingJob->attempts || !$pendingJob->failure_message) {
+					if (!$pendingJob->failure_message) {
 						echo '<li>';
 						echo __d('queue', 'Progress') . ': ';
 						echo $this->QueueProgress->progress($pendingJob) . $status;
@@ -92,7 +92,7 @@ use Cake\Core\Configure;
 						echo '</li>';
 					} else {
 						echo '<li><i>' . $this->Queue->failureStatus($pendingJob) . '</i>';
-  						echo '<div>' . __d('queue', 'Failures') . ': ' . $this->Queue->fails($pendingJob) . $reset . '</div>';
+  						echo '<div>' . __d('queue', 'Attempts') . ': ' . $this->Queue->attempts($pendingJob) . $reset . '</div>';
   						echo '</li>';
 						if ($pendingJob->failure_message) {
 							echo '<li>' . __d('queue', 'Failure Message') . ': ' . $this->Text->truncate($pendingJob->failure_message, 200) . '</li>';

--- a/templates/Admin/QueuedJobs/index.php
+++ b/templates/Admin/QueuedJobs/index.php
@@ -44,7 +44,7 @@ use Cake\Core\Plugin;
 				<th><?= $this->Paginator->sort('notbefore', null, ['direction' => 'desc']) ?></th>
 				<th><?= $this->Paginator->sort('fetched', null, ['direction' => 'desc']) ?></th>
 				<th><?= $this->Paginator->sort('completed', null, ['direction' => 'desc']) ?></th>
-				<th><?= $this->Paginator->sort('failed') ?></th>
+				<th><?= $this->Paginator->sort('attempts') ?></th>
 				<th><?= $this->Paginator->sort('status') ?></th>
 				<th><?= $this->Paginator->sort('priority', null, ['direction' => 'desc']) ?></th>
 				<th class="actions"><?= __d('queue', 'Actions') ?></th>
@@ -96,12 +96,12 @@ use Cake\Core\Plugin;
                     </div>
                     <?php } ?>
                 </td>
-				<td><?= $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->failed); ?></td>
+				<td><?= $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->attempts); ?></td>
 				<td>
 					<?= h($queuedJob->status) ?>
 					<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
 						<div>
-							<?php if (!$queuedJob->failed) { ?>
+							<?php if (!$queuedJob->attempts) { ?>
 								<?php echo $this->QueueProgress->progress($queuedJob) ?>
 								<br>
 								<?php

--- a/templates/Admin/QueuedJobs/index.php
+++ b/templates/Admin/QueuedJobs/index.php
@@ -96,12 +96,12 @@ use Cake\Core\Plugin;
                     </div>
                     <?php } ?>
                 </td>
-				<td><?= $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->attempts); ?></td>
+				<td><?= $this->Format->ok($this->Queue->attempts($queuedJob), $queuedJob->completed || $queuedJob->attempts < 1); ?></td>
 				<td>
 					<?= h($queuedJob->status) ?>
 					<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
 						<div>
-							<?php if (!$queuedJob->attempts) { ?>
+							<?php if (!$queuedJob->failure_message) { ?>
 								<?php echo $this->QueueProgress->progress($queuedJob) ?>
 								<br>
 								<?php

--- a/templates/Admin/QueuedJobs/view.php
+++ b/templates/Admin/QueuedJobs/view.php
@@ -83,7 +83,7 @@ use Queue\Utility\Serializer;
 			<th><?= __d('queue', 'Progress') ?></th>
 			<td>
 				<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
-					<?php if (!$queuedJob->failed || !$queuedJob->failure_message) { ?>
+					<?php if (!$queuedJob->attempts || !$queuedJob->failure_message) { ?>
 						<?php echo $this->QueueProgress->progress($queuedJob) ?>
 						<br>
 						<?php
@@ -99,11 +99,11 @@ use Queue\Utility\Serializer;
 		<tr>
 			<th><?= __d('queue', 'Failed') ?></th>
 			<td>
-				<?= $queuedJob->failed ? $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->failed)  : '' ?>
+				<?= $queuedJob->attempts ? $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->attempts)  : '' ?>
 				<?php
 				if ($this->Queue->hasFailed($queuedJob)) {
 					echo ' ' . $this->Form->postLink(__d('queue', 'Soft reset'), ['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id], ['confirm' => 'Sure?', 'class' => 'button button-primary btn margin btn-primary']);
-				} elseif (!$queuedJob->completed && $queuedJob->fetched && $queuedJob->failed && $queuedJob->failure_message) {
+				} elseif (!$queuedJob->completed && $queuedJob->fetched && $queuedJob->attempts && $queuedJob->failure_message) {
 					echo ' ' . $this->Form->postLink(__d('queue', 'Force reset'), ['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id], ['confirm' => 'Sure? This job is currently waiting to be re-queued.', 'class' => 'button button-primary btn margin btn-primary']);
 				}
 				?>

--- a/templates/Admin/QueuedJobs/view.php
+++ b/templates/Admin/QueuedJobs/view.php
@@ -83,7 +83,7 @@ use Queue\Utility\Serializer;
 			<th><?= __d('queue', 'Progress') ?></th>
 			<td>
 				<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
-					<?php if (!$queuedJob->attempts || !$queuedJob->failure_message) { ?>
+					<?php if (!$queuedJob->failure_message) { ?>
 						<?php echo $this->QueueProgress->progress($queuedJob) ?>
 						<br>
 						<?php
@@ -97,9 +97,9 @@ use Queue\Utility\Serializer;
 			</td>
 		</tr>
 		<tr>
-			<th><?= __d('queue', 'Failed') ?></th>
+			<th><?= __d('queue', 'Attempts') ?></th>
 			<td>
-				<?= $queuedJob->attempts ? $this->Format->ok($this->Queue->fails($queuedJob), !$queuedJob->attempts)  : '' ?>
+				<?= $queuedJob->attempts ? $this->Format->ok($this->Queue->attempts($queuedJob), $queuedJob->completed || $queuedJob->attempts < 1) : '' ?>
 				<?php
 				if ($this->Queue->hasFailed($queuedJob)) {
 					echo ' ' . $this->Form->postLink(__d('queue', 'Soft reset'), ['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id], ['confirm' => 'Sure?', 'class' => 'button button-primary btn margin btn-primary']);

--- a/tests/Fixture/QueuedJobsFixture.php
+++ b/tests/Fixture/QueuedJobsFixture.php
@@ -28,7 +28,7 @@ class QueuedJobsFixture extends TestFixture {
         'fetched' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'completed' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'progress' => ['type' => 'float', 'length' => null, 'precision' => null, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => ''],
-        'failed' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => 0, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'attempts' => ['type' => 'integer', 'length' => 12, 'unsigned' => false, 'null' => false, 'default' => 0, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
         'failure_message' => ['type' => 'text', 'length' => 16777215, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'workerkey' => ['type' => 'string', 'length' => 45, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
         'status' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -116,7 +116,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -135,7 +135,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -145,7 +145,7 @@ class QueueControllerTest extends TestCase {
 
 		/** @var \Queue\Model\Entity\QueuedJob $job */
 		$job = $jobsTable->find()->where(['id' => $job->id])->firstOrFail();
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 	}
 
 	/**
@@ -155,7 +155,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -167,7 +167,7 @@ class QueueControllerTest extends TestCase {
 
 		/** @var \Queue\Model\Entity\QueuedJob $job */
 		$job = $jobsTable->find()->where(['id' => $job->id])->firstOrFail();
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 	}
 
 	/**
@@ -177,7 +177,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -189,7 +189,7 @@ class QueueControllerTest extends TestCase {
 
 		/** @var \Queue\Model\Entity\QueuedJob $job */
 		$job = $jobsTable->find()->where(['id' => $job->id])->firstOrFail();
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 	}
 
 	/**
@@ -199,7 +199,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -215,7 +215,7 @@ class QueueControllerTest extends TestCase {
 
 		/** @var \Queue\Model\Entity\QueuedJob $job */
 		$job = $jobsTable->find()->where(['id' => $job->id])->firstOrFail();
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 	}
 
 	/**
@@ -225,7 +225,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 		]);
 		$jobsTable->saveOrFail($job);
 
@@ -235,7 +235,7 @@ class QueueControllerTest extends TestCase {
 
 		/** @var \Queue\Model\Entity\QueuedJob $job */
 		$job = $jobsTable->get($job->id);
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 	}
 
 	/**
@@ -245,7 +245,7 @@ class QueueControllerTest extends TestCase {
 		$jobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
 		$job = $jobsTable->newEntity([
 			'job_task' => 'foo',
-			'failed' => 1,
+			'attempts' => 1,
 			'fetched' => (new DateTime())->subHours(1),
 		]);
 		$jobsTable->saveOrFail($job);

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -174,7 +174,7 @@ class QueuedJobsTableTest extends TestCase {
 		$job = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame(1, $job->id);
 		$this->assertSame('Foo', $job->job_task);
-		$this->assertSame(0, $job->failed);
+		$this->assertSame(0, $job->attempts);
 		$this->assertNull($job->completed);
 		$this->assertSame($testData, unserialize($job->data));
 
@@ -486,14 +486,14 @@ class QueuedJobsTableTest extends TestCase {
 		$tmp = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame('Foo', $tmp['job_task']);
 		$this->assertSame($data, unserialize($tmp['data']));
-		$this->assertSame(0, $tmp['failed']);
+		$this->assertSame(0, $tmp['attempts']);
 		sleep(2);
 
 		$this->QueuedJobs->clearKey();
 		$tmp = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame('Foo', $tmp['job_task']);
 		$this->assertSame($data, unserialize($tmp['data']));
-		$this->assertSame(1, $tmp['failed']);
+		$this->assertSame(1, $tmp['attempts']);
 		$this->assertSame('Restart after timeout', $tmp['failure_message']);
 	}
 
@@ -527,14 +527,14 @@ class QueuedJobsTableTest extends TestCase {
 		$tmp = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame('Foo', $tmp['job_task']);
 		$this->assertSame(['1'], unserialize($tmp['data']));
-		$this->assertSame('0', $tmp['failed']);
+		$this->assertSame('0', $tmp['attempts']);
 		sleep(2);
 
 		$this->QueuedJobs->clearKey();
 		$tmp = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame('Foo', $tmp['job_task']);
 		$this->assertSame(['1'], unserialize($tmp['data']));
-		$this->assertSame('1', $tmp['failed']);
+		$this->assertSame('1', $tmp['attempts']);
 		$this->assertSame('Restart after timeout', $tmp['failure_message']);
 	}
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -174,7 +174,7 @@ class QueuedJobsTableTest extends TestCase {
 		$job = $this->QueuedJobs->requestJob($capabilities);
 		$this->assertSame(1, $job->id);
 		$this->assertSame('Foo', $job->job_task);
-		$this->assertSame(0, $job->attempts);
+		$this->assertSame(1, $job->attempts);
 		$this->assertNull($job->completed);
 		$this->assertSame($testData, unserialize($job->data));
 

--- a/tests/TestCase/View/Helper/QueueHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueHelperTest.php
@@ -67,19 +67,19 @@ class QueueHelperTest extends TestCase {
 			'job_task' => 'Queue.Example',
 			'attempts' => 0,
 		]);
-		$result = $this->QueueHelper->fails($queuedJob);
+		$result = $this->QueueHelper->attempts($queuedJob);
 		$this->assertSame('0x', $result);
 
 		$queuedJob->attempts = 1;
-		$result = $this->QueueHelper->fails($queuedJob);
+		$result = $this->QueueHelper->attempts($queuedJob);
 		$this->assertSame('1/2', $result);
 
 		$queuedJob->attempts = 2;
-		$result = $this->QueueHelper->fails($queuedJob);
+		$result = $this->QueueHelper->attempts($queuedJob);
 		$this->assertSame('2/2', $result);
 
 		$queuedJob->job_task = 'Queue.ExampleInvalid';
-		$result = $this->QueueHelper->fails($queuedJob);
+		$result = $this->QueueHelper->attempts($queuedJob);
 		$this->assertSame('2x', $result);
 	}
 

--- a/tests/TestCase/View/Helper/QueueHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueHelperTest.php
@@ -39,21 +39,21 @@ class QueueHelperTest extends TestCase {
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
 			'fetched' => '2019',
-			'failed' => 0,
+			'attempts' => 0,
 		]);
 		$result = $this->QueueHelper->hasFailed($queuedJob);
 		$this->assertFalse($result);
 
-		$queuedJob->failed = 1;
+		$queuedJob->attempts = 1;
 		$queuedJob->failure_message = 'Foo';
 		$result = $this->QueueHelper->hasFailed($queuedJob);
 		$this->assertFalse($result);
 
-		$queuedJob->failed = 999;
+		$queuedJob->attempts = 999;
 		$result = $this->QueueHelper->hasFailed($queuedJob);
 		$this->assertTrue($result);
 
-		$queuedJob->failed = 999;
+		$queuedJob->attempts = 999;
 		$queuedJob->failure_message = null;
 		$result = $this->QueueHelper->hasFailed($queuedJob);
 		$this->assertFalse($result);
@@ -65,16 +65,16 @@ class QueueHelperTest extends TestCase {
 	public function testFails() {
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
-			'failed' => 0,
+			'attempts' => 0,
 		]);
 		$result = $this->QueueHelper->fails($queuedJob);
 		$this->assertSame('0x', $result);
 
-		$queuedJob->failed = 1;
+		$queuedJob->attempts = 1;
 		$result = $this->QueueHelper->fails($queuedJob);
 		$this->assertSame('1/2', $result);
 
-		$queuedJob->failed = 2;
+		$queuedJob->attempts = 2;
 		$result = $this->QueueHelper->fails($queuedJob);
 		$this->assertSame('2/2', $result);
 
@@ -90,12 +90,12 @@ class QueueHelperTest extends TestCase {
 		$queuedJob = new QueuedJob([
 			'job_task' => 'Queue.Example',
 			'fetched' => '2019',
-			'failed' => 0,
+			'attempts' => 0,
 		]);
 		$result = $this->QueueHelper->failureStatus($queuedJob);
 		$this->assertNull($result);
 
-		$queuedJob->failed = 1;
+		$queuedJob->attempts = 1;
 		$queuedJob->failure_message = 'Foo';
 		$result = $this->QueueHelper->failureStatus($queuedJob);
 		$this->assertSame(__d('queue', 'Requeued'), $result);
@@ -104,7 +104,7 @@ class QueueHelperTest extends TestCase {
 		$result = $this->QueueHelper->failureStatus($queuedJob);
 		$this->assertSame('Restarted', $result);
 
-		$queuedJob->failed = 999;
+		$queuedJob->attempts = 999;
 		$queuedJob->failure_message = 'Foo';
 		$result = $this->QueueHelper->failureStatus($queuedJob);
 		$this->assertSame('Aborted', $result);

--- a/tests/test_files/queued-job.json
+++ b/tests/test_files/queued-job.json
@@ -10,7 +10,7 @@
         "fetched": null,
         "completed": null,
         "progress": null,
-        "failed": 0,
+        "attempts": 0,
         "failure_message": null,
         "workerkey": null,
         "status": null,


### PR DESCRIPTION
Change "failed" column to "attempts" and update logic accordingly (and increment this value prior to job execution).

If I have a job that causes the process to run out of memory, the job is never marked as failed, and later workers will pick it up and try to execute it again regardless of the "retries" task property. This can cause the queue_processes table to fill up when there are in fact no workers running, and prevents the start up of new workers.

There are a few ways around this but I feel like the above would be a simpler way to prevent this kind of problem from happening.