### PR TITLE
Fixing tests for cake5 upgrade

### DIFF
--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -8,7 +8,6 @@ use Cake\Core\Plugin;
 use Cake\Http\Exception\NotFoundException;
 use Cake\I18n\DateTime;
 use Cake\View\JsonView;
-use Laminas\Diactoros\UploadedFile;
 use Queue\Queue\TaskFinder;
 use RuntimeException;
 

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -128,7 +128,7 @@ class QueuedJobsController extends AppController {
 	   */
 	public function import() {
 		if ($this->request->is(['post'])) {
-			/** @var \Laminas\Diactoros\UploadedFile|array<string, mixed> $file */
+			/** @var \Laminas\Diactoros\UploadedFile|null $file */
 			$file = $this->request->getData('file');
 			if ($file && $file->getError() == UPLOAD_ERR_OK && $file->getSize() > 0) {
 				$content = file_get_contents($file->getStream()->getMetadata('uri'));

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -5,6 +5,7 @@ namespace Queue\Test\TestCase\Controller\Admin;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\IntegrationTestTrait;
+use Laminas\Diactoros\UploadedFile;
 use Shim\TestSuite\TestCase;
 
 /**
@@ -173,11 +174,7 @@ class QueuedJobsControllerTest extends TestCase {
 		$jsonFile = TESTS . 'test_files' . DS . 'queued-job.json';
 
 		$data = [
-			'file' => [
-				'size' => 1,
-				'error' => 0,
-				'tmp_name' => $jsonFile,
-			],
+			'file' => new UploadedFile($jsonFile, 1, 0, 'queued-job.json', 'application/json'),
 		];
 
 		$this->post(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'import'], $data);

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -12,7 +12,6 @@ use Queue\Console\Io;
 use Queue\Queue\Processor;
 use Shim\TestSuite\ConsoleOutput;
 use Shim\TestSuite\TestTrait;
-use TestApp\Model\Table\CategoriesTable;
 
 class ProcessorTest extends TestCase {
 

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -101,21 +101,6 @@ class ProcessorTest extends TestCase {
 	}
 
 	/**
-	 * This checks if the old loadModel function still works
-	 * @return void
-	 */
-	public function testModelAwareTrait() {
-		$this->_needsConnection();
-
-		$out = new ConsoleOutput();
-		$err = new ConsoleOutput();
-		$this->Processor = new Processor(new Io(new ConsoleIo($out, $err)), new NullLogger());
-
-		$this->Processor->loadModel('Categories');
-		$this->assertInstanceOf(CategoriesTable::class, $this->Processor->Categories);
-	}
-
-	/**
 	 * Helper method for skipping tests that need a real connection.
 	 *
 	 * @return void


### PR DESCRIPTION
There were 2 failing tests, one is fixed, one is removed because it referenced a deprecated trait