### PR TITLE
Load configuration by default

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -24,6 +24,26 @@ class Plugin extends BasePlugin {
 	 * @var bool
 	 */
 	protected $middlewareEnabled = false;
+	
+	/**
+	 * Load all the plugin configuration and bootstrap logic.
+	 *
+	 * The host application is provided as an argument. This allows you to load
+	 * additional plugin dependencies, or attach events.
+	 *
+	 * @param \Cake\Core\PluginApplicationInterface $app The host application
+	 * @return void
+	 */
+	public function bootstrap(PluginApplicationInterface $app): void
+	{
+		parent::bootstrap($app);
+
+		$appConfig = Configure::read('Queue');
+		Configure::load('Queue.app_queue');
+		$config = Configure::read('Queue');
+		$config = Hash::merge($config, $appConfig);
+		Configure::write('Queue', $config);
+	}
 
 	/**
 	 * Console hook


### PR DESCRIPTION
loads the default-configuration-file like stated in the documentation 

Resolves https://github.com/dereuromark/cakephp-queue/issues/372