### PR TITLE
Expose kill signal parameter from terminateProcess() in delete() 

### DIFF
--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -104,14 +104,15 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
+	 * @param int|null $id Signal (defaults to graceful SITERM = 15).
 	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
-	public function delete($id = null) {
+	public function delete($id = null, $sig = null) {
 		$this->request->allowMethod(['post', 'delete']);
 		$queueProcess = $this->QueueProcesses->get($id);
 
 		if (!Configure::read('Queue.multiserver')) {
-			$this->QueueProcesses->terminateProcess($queueProcess->pid);
+			$this->QueueProcesses->terminateProcess($queueProcess->pid, $sig);
 		}
 
 		if ($this->QueueProcesses->delete($queueProcess)) {

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -104,10 +104,10 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
-	 * @param int|null $sig Signal (defaults to graceful SITERM = 15).
+	 * @param int $sig Signal (defaults to graceful SIGTERM = 15).
 	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
-	public function delete($id = null, $sig = null) {
+	public function delete($id = null, $sig = SIGTERM) {
 		$this->request->allowMethod(['post', 'delete']);
 		$queueProcess = $this->QueueProcesses->get($id);
 

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -104,7 +104,7 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
-	 * @param int|null $id Signal (defaults to graceful SITERM = 15).
+	 * @param int|null $sig Signal (defaults to graceful SITERM = 15).
 	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
 	public function delete($id = null, $sig = null) {

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -275,7 +275,7 @@ class QueueProcessesTable extends Table {
 	 * We might need to run some exec() kill command here instead.
 	 *
 	 * @param string $pid
-	 * @param int|null $sig Signal (defaults to graceful SIGTERM = 15)
+	 * @param int $sig Signal (defaults to graceful SIGTERM = 15)
 	 * @return void
 	 */
 	public function terminateProcess(string $pid, int $sig = SIGTERM): void {

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -275,7 +275,7 @@ class QueueProcessesTable extends Table {
 	 * We might need to run some exec() kill command here instead.
 	 *
 	 * @param string $pid
-	 * @param int $sig Signal (defaults to graceful SIGTERM = 15)
+	 * @param int|null $sig Signal (defaults to graceful SIGTERM = 15)
 	 * @return void
 	 */
 	public function terminateProcess(string $pid, int $sig = SIGTERM): void {


### PR DESCRIPTION
I need to use a SIGKILL instead of a SIGTERM for terminating a job. This allows that functionality without having to modify the vendor package