### PR TITLE
5.x: add property types, return types, declare strict types

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,7 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <exclude-pattern>*/config/Migrations/*</exclude-pattern>
     </rule>
+	<rule ref="Spryker.Commenting.DocBlockTagGrouping"/>
     <rule ref="Spryker.Classes.ClassFileName.NoMatch">
         <exclude-pattern>*/config/Migrations/*</exclude-pattern>
     </rule>

--- a/src/Command/AddCommand.php
+++ b/src/Command/AddCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -42,7 +43,7 @@ class AddCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
-	 * @return int|null|void
+	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks();

--- a/src/Command/AddCommand.php
+++ b/src/Command/AddCommand.php
@@ -44,7 +44,7 @@ class AddCommand extends Command {
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
 	 *
-	 * @return null|void
+	 * @return int|null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks();

--- a/src/Command/AddCommand.php
+++ b/src/Command/AddCommand.php
@@ -43,6 +43,7 @@ class AddCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {

--- a/src/Command/BakeQueueTaskCommand.php
+++ b/src/Command/BakeQueueTaskCommand.php
@@ -49,6 +49,7 @@ class BakeQueueTaskCommand extends SimpleBakeCommand {
 	 * @param string $name The class to bake a test for.
 	 * @param \Cake\Console\Arguments $args The console arguments
 	 * @param \Cake\Console\ConsoleIo $io The console io
+	 *
 	 * @return void
 	 */
 	public function bakeTest(string $name, Arguments $args, ConsoleIo $io): void {
@@ -72,6 +73,7 @@ class BakeQueueTaskCommand extends SimpleBakeCommand {
 	/**
 	 * @param string $name
 	 * @param string $namespace
+	 *
 	 * @return string
 	 */
 	protected function generateTaskTestContent(string $name, string $namespace): string {
@@ -159,7 +161,7 @@ TXT;
 			'plugin' => $this->plugin,
 			'pluginPath' => $pluginPath,
 			'namespace' => $namespace,
-			'subNamespace' => $namespacePart ? $namespacePart . '/' : '',
+			'subNamespace' => $namespacePart ? ($namespacePart . '/') : '',
 			'name' => $name,
 			'add' => $arguments->getOption('add'),
 		];
@@ -183,6 +185,7 @@ TXT;
 	 * Gets the option parser instance and configures it.
 	 *
 	 * @param \Cake\Console\ConsoleOptionParser $parser Parser instance
+	 *
 	 * @return \Cake\Console\ConsoleOptionParser
 	 */
 	public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser {

--- a/src/Command/BakeQueueTaskCommand.php
+++ b/src/Command/BakeQueueTaskCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -24,7 +25,7 @@ class BakeQueueTaskCommand extends SimpleBakeCommand {
 	/**
 	 * @var string
 	 */
-	protected $_name;
+	protected string $_name;
 
 	/**
 	 * @inheritDoc
@@ -71,7 +72,6 @@ class BakeQueueTaskCommand extends SimpleBakeCommand {
 	/**
 	 * @param string $name
 	 * @param string $namespace
-	 *
 	 * @return string
 	 */
 	protected function generateTaskTestContent(string $name, string $namespace): string {
@@ -102,7 +102,7 @@ class $testName extends TestCase {
 	/**
 	 * @var array<string>
 	 */
-	protected \$fixtures = [
+	protected array \$fixtures = [
 		'plugin.Queue.QueuedJobs',
 		'plugin.Queue.QueueProcesses',
 	];
@@ -159,7 +159,7 @@ TXT;
 			'plugin' => $this->plugin,
 			'pluginPath' => $pluginPath,
 			'namespace' => $namespace,
-			'subNamespace' => $namespacePart ? ($namespacePart . '/') : '',
+			'subNamespace' => $namespacePart ? $namespacePart . '/' : '',
 			'name' => $name,
 			'add' => $arguments->getOption('add'),
 		];

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -42,7 +42,7 @@ class InfoCommand extends Command {
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
 	 *
-	 * @return null|void
+	 * @return int|null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks();

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -40,7 +41,7 @@ class InfoCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
-	 * @return int|null|void
+	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks();

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -41,6 +41,7 @@ class InfoCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -65,6 +65,7 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return int|null
 	 */
 	public function execute(Arguments $args, ConsoleIo $io): int|null {
@@ -129,6 +130,7 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function rerunAll(ConsoleIo $io): int {
@@ -148,6 +150,7 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function resetAll(ConsoleIo $io): int {
@@ -167,6 +170,7 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function removeAll(ConsoleIo $io): int {
@@ -184,6 +188,7 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return int
 	 */
 	protected function rerun(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -203,6 +208,7 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return int
 	 */
 	protected function reset(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -222,6 +228,7 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return int
 	 */
 	protected function remove(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -235,6 +242,7 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return int
 	 */
 	protected function view(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -260,6 +268,7 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function flush(ConsoleIo $io): int {
@@ -271,6 +280,7 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function clean(ConsoleIo $io): int {

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -33,8 +34,8 @@ class JobCommand extends Command {
 	}
 
 	/**
-	   * @inheritDoc
-	   */
+	 * @inheritDoc
+	 */
 	public static function defaultName(): string {
 		return 'queue job';
 	}
@@ -64,9 +65,9 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
-	 * @return int|null|void
+	 * @return int|null
 	 */
-	public function execute(Arguments $args, ConsoleIo $io) {
+	public function execute(Arguments $args, ConsoleIo $io): int|null {
 		$action = $args->getArgument('action');
 		if (!$action) {
 			$io->out('Please use with [action] [ID] added.');
@@ -128,7 +129,6 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function rerunAll(ConsoleIo $io): int {
@@ -148,7 +148,6 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function resetAll(ConsoleIo $io): int {
@@ -168,7 +167,6 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function removeAll(ConsoleIo $io): int {
@@ -186,7 +184,6 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return int
 	 */
 	protected function rerun(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -206,7 +203,6 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return int
 	 */
 	protected function reset(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -226,7 +222,6 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return int
 	 */
 	protected function remove(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -240,7 +235,6 @@ class JobCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return int
 	 */
 	protected function view(ConsoleIo $io, QueuedJob $queuedJob): int {
@@ -266,7 +260,6 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function flush(ConsoleIo $io): int {
@@ -278,7 +271,6 @@ class JobCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function clean(ConsoleIo $io): int {

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -66,9 +66,9 @@ class JobCommand extends Command {
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
 	 *
-	 * @return int|null
+	 * @return int|null|void
 	 */
-	public function execute(Arguments $args, ConsoleIo $io): int|null {
+	public function execute(Arguments $args, ConsoleIo $io) {
 		$action = $args->getArgument('action');
 		if (!$action) {
 			$io->out('Please use with [action] [ID] added.');

--- a/src/Command/MigrateTasksCommand.php
+++ b/src/Command/MigrateTasksCommand.php
@@ -56,6 +56,7 @@ class MigrateTasksCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
@@ -125,6 +126,7 @@ class MigrateTasksCommand extends Command {
 	 * @param string|null $plugin
 	 * @param string $oldPath
 	 * @param string $newPath
+	 *
 	 * @return void
 	 */
 	protected function migrateTask(string $name, ?string $plugin, string $oldPath, string $newPath): void {
@@ -184,6 +186,7 @@ class MigrateTasksCommand extends Command {
 	 * @param string|null $plugin
 	 * @param string $oldPath
 	 * @param string $newPath
+	 *
 	 * @return void
 	 */
 	protected function migrateTaskTest(string $name, ?string $plugin, string $oldPath, string $newPath): void {
@@ -226,6 +229,7 @@ class MigrateTasksCommand extends Command {
 
 	/**
 	 * @param string|null $plugin
+	 *
 	 * @return array<string>
 	 */
 	protected function getTasks(?string $plugin): array {

--- a/src/Command/MigrateTasksCommand.php
+++ b/src/Command/MigrateTasksCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -55,7 +56,7 @@ class MigrateTasksCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
-	 * @return int|null|void
+	 * @return null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks($args->getOption('plugin') ? (string)$args->getOption('plugin') : null);
@@ -225,7 +226,6 @@ class MigrateTasksCommand extends Command {
 
 	/**
 	 * @param string|null $plugin
-	 *
 	 * @return array<string>
 	 */
 	protected function getTasks(?string $plugin): array {

--- a/src/Command/MigrateTasksCommand.php
+++ b/src/Command/MigrateTasksCommand.php
@@ -57,7 +57,7 @@ class MigrateTasksCommand extends Command {
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
 	 *
-	 * @return null|void
+	 * @return int|null|void
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$tasks = $this->getTasks($args->getOption('plugin') ? (string)$args->getOption('plugin') : null);

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -21,7 +22,7 @@ class RunCommand extends Command {
 	/**
 	 * @var \Cake\Core\ContainerInterface
 	 */
-	protected $container;
+	protected ContainerInterface $container;
 
 	/**
 	 * @param \Cake\Core\ContainerInterface $container

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -82,6 +82,7 @@ class RunCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
+	 *
 	 * @return \Psr\Log\LoggerInterface
 	 */
 	protected function getLogger(Arguments $args): LoggerInterface {
@@ -100,6 +101,7 @@ class RunCommand extends Command {
 	 *
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return int
 	 */
 	public function execute(Arguments $args, ConsoleIo $io): int {

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -64,9 +64,9 @@ class WorkerCommand extends Command {
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
 	 *
-	 * @return int|null
+	 * @return int|null|void
 	 */
-	public function execute(Arguments $args, ConsoleIo $io): int|null {
+	public function execute(Arguments $args, ConsoleIo $io) {
 		$action = $args->getArgument('action');
 		if (!$action) {
 			$io->out('Please use with [action] [PID] added.');

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -63,6 +63,7 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
+	 *
 	 * @return int|null
 	 */
 	public function execute(Arguments $args, ConsoleIo $io): int|null {
@@ -110,6 +111,7 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param string $pid
+	 *
 	 * @return int
 	 */
 	protected function end(ConsoleIo $io, string $pid): int {
@@ -139,6 +141,7 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param string $pid
+	 *
 	 * @return int
 	 */
 	protected function kill(ConsoleIo $io, string $pid): int {
@@ -180,6 +183,7 @@ class WorkerCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 *
 	 * @return int
 	 */
 	protected function clean(ConsoleIo $io): int {

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Command;
 
@@ -31,8 +32,8 @@ class WorkerCommand extends Command {
 	}
 
 	/**
-	   * @inheritDoc
-	   */
+	 * @inheritDoc
+	 */
 	public static function defaultName(): string {
 		return 'queue job';
 	}
@@ -62,9 +63,9 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\Arguments $args Arguments
 	 * @param \Cake\Console\ConsoleIo $io ConsoleIo
-	 * @return int|null|void
+	 * @return int|null
 	 */
-	public function execute(Arguments $args, ConsoleIo $io) {
+	public function execute(Arguments $args, ConsoleIo $io): int|null {
 		$action = $args->getArgument('action');
 		if (!$action) {
 			$io->out('Please use with [action] [PID] added.');
@@ -109,7 +110,6 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param string $pid
-	 *
 	 * @return int
 	 */
 	protected function end(ConsoleIo $io, string $pid): int {
@@ -139,7 +139,6 @@ class WorkerCommand extends Command {
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
 	 * @param string $pid
-	 *
 	 * @return int
 	 */
 	protected function kill(ConsoleIo $io, string $pid): int {
@@ -181,7 +180,6 @@ class WorkerCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
-	 *
 	 * @return int
 	 */
 	protected function clean(ConsoleIo $io): int {

--- a/src/Console/Io.php
+++ b/src/Console/Io.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Console;
 
@@ -15,7 +16,7 @@ class Io {
 	/**
 	 * @var \Cake\Console\ConsoleIo
 	 */
-	protected $_io;
+	protected ConsoleIo $_io;
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
@@ -31,7 +32,7 @@ class Io {
 	 * @param int $newlines Number of newlines to append
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function verbose($message, $newlines = 1) {
+	public function verbose(array|string $message, int $newlines = 1): ?int {
 		return $this->_io->verbose($message, $newlines);
 	}
 
@@ -42,7 +43,7 @@ class Io {
 	 * @param int $newlines Number of newlines to append
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function quiet($message, $newlines = 1) {
+	public function quiet(array|string $message, int $newlines = 1): ?int {
 		return $this->_io->quiet($message, $newlines);
 	}
 
@@ -63,7 +64,7 @@ class Io {
 	 * @param int $level The message's output level, see above.
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function out($message = '', $newlines = 1, $level = ConsoleIo::NORMAL) {
+	public function out(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
 		return $this->_io->out($message, $newlines, $level);
 	}
 
@@ -75,7 +76,7 @@ class Io {
 	 * @param int $newlines Number of newlines to append
 	 * @return int|null The number of bytes returned from writing to stderr.
 	 */
-	public function err($message = '', $newlines = 1) {
+	public function err(array|string $message = '', int $newlines = 1): ?int {
 		$messages = (array)$message;
 		foreach ($messages as $key => $message) {
 			$messages[$key] = '<error>' . $message . '</error>';
@@ -93,7 +94,7 @@ class Io {
 	 * @param int $level The message's output level, see above.
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function info($message = '', $newlines = 1, $level = ConsoleIo::NORMAL) {
+	public function info(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
 		$messages = (array)$message;
 		foreach ($messages as $key => $message) {
 			$messages[$key] = '<info>' . $message . '</info>';
@@ -111,7 +112,7 @@ class Io {
 	 * @param int $level The message's output level, see above.
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function comment($message = '', $newlines = 1, $level = ConsoleIo::NORMAL) {
+	public function comment(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
 		$messages = (array)$message;
 		foreach ($messages as $key => $message) {
 			$messages[$key] = '<comment>' . $message . '</comment>';
@@ -128,7 +129,7 @@ class Io {
 	 * @param int $newlines Number of newlines to append
 	 * @return int|null The number of bytes returned from writing to stderr.
 	 */
-	public function warn($message = '', $newlines = 1) {
+	public function warn(array|string $message = '', int $newlines = 1): ?int {
 		$messages = (array)$message;
 		foreach ($messages as $key => $message) {
 			$messages[$key] = '<warning>' . $message . '</warning>';
@@ -146,7 +147,7 @@ class Io {
 	 * @param int $level The message's output level, see above.
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
-	public function success($message = '', $newlines = 1, $level = ConsoleIo::NORMAL) {
+	public function success(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
 		$messages = (array)$message;
 		foreach ($messages as $key => $message) {
 			$messages[$key] = '<success>' . $message . '</success>';
@@ -162,7 +163,7 @@ class Io {
 	 * @param int $multiplier Number of times the linefeed sequence should be repeated
 	 * @return string
 	 */
-	public function nl($multiplier = 1) {
+	public function nl(int $multiplier = 1): string {
 		return $this->_io->nl($multiplier);
 	}
 
@@ -174,7 +175,7 @@ class Io {
 	 * @param int $width Width of the line, defaults to 63
 	 * @return void
 	 */
-	public function hr($newlines = 0, $width = 63) {
+	public function hr(int $newlines = 0, int $width = 63): void {
 		$this->_io->hr($newlines, $width);
 	}
 
@@ -188,7 +189,7 @@ class Io {
 	 * @throws \Cake\Console\Exception\StopException
 	 * @return void
 	 */
-	public function abort($message, $exitCode = CommandInterface::CODE_ERROR) {
+	public function abort(string $message, int $exitCode = CommandInterface::CODE_ERROR): void {
 		$this->_io->err('<error>' . $message . '</error>');
 
 		throw new StopException($message, $exitCode);
@@ -220,7 +221,7 @@ class Io {
 	 *    length of the last message output.
 	 * @return void
 	 */
-	public function overwrite($message, int $newlines = 1, ?int $size = null): void {
+	public function overwrite(array|string $message, int $newlines = 1, ?int $size = null): void {
 		$this->_io->overwrite($message, $newlines, $size);
 	}
 

--- a/src/Console/Io.php
+++ b/src/Console/Io.php
@@ -30,6 +30,7 @@ class Io {
 	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function verbose(array|string $message, int $newlines = 1): ?int {
@@ -41,6 +42,7 @@ class Io {
 	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function quiet(array|string $message, int $newlines = 1): ?int {
@@ -59,9 +61,11 @@ class Io {
 	 * While using ConsoleIo::VERBOSE means it will only display when verbose output is toggled.
 	 *
 	 * @link https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
 	 * @param int $level The message's output level, see above.
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function out(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
@@ -74,6 +78,7 @@ class Io {
 	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
+	 *
 	 * @return int|null The number of bytes returned from writing to stderr.
 	 */
 	public function err(array|string $message = '', int $newlines = 1): ?int {
@@ -89,9 +94,11 @@ class Io {
 	 * Convenience method for out() that wraps message between <info /> tag
 	 *
 	 * @see https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
 	 * @param int $level The message's output level, see above.
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function info(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
@@ -107,9 +114,11 @@ class Io {
 	 * Convenience method for out() that wraps message between <comment /> tag
 	 *
 	 * @see https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
 	 * @param int $level The message's output level, see above.
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function comment(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
@@ -125,8 +134,10 @@ class Io {
 	 * Convenience method for err() that wraps message between <warning /> tag
 	 *
 	 * @see https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
+	 *
 	 * @return int|null The number of bytes returned from writing to stderr.
 	 */
 	public function warn(array|string $message = '', int $newlines = 1): ?int {
@@ -142,9 +153,11 @@ class Io {
 	 * Convenience method for out() that wraps message between <success /> tag
 	 *
 	 * @see https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param array<string>|string $message A string or an array of strings to output
 	 * @param int $newlines Number of newlines to append
 	 * @param int $level The message's output level, see above.
+	 *
 	 * @return int|null The number of bytes returned from writing to stdout.
 	 */
 	public function success(array|string $message = '', int $newlines = 1, int $level = ConsoleIo::NORMAL): ?int {
@@ -160,7 +173,9 @@ class Io {
 	 * Returns a single or multiple linefeeds sequences.
 	 *
 	 * @link https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param int $multiplier Number of times the linefeed sequence should be repeated
+	 *
 	 * @return string
 	 */
 	public function nl(int $multiplier = 1): string {
@@ -171,8 +186,10 @@ class Io {
 	 * Outputs a series of minus characters to the standard output, acts as a visual separator.
 	 *
 	 * @link https://book.cakephp.org/4/en/console-commands/input-output.html#creating-output
+	 *
 	 * @param int $newlines Number of newlines to pre- and append
 	 * @param int $width Width of the line, defaults to 63
+	 *
 	 * @return void
 	 */
 	public function hr(int $newlines = 0, int $width = 63): void {
@@ -184,9 +201,12 @@ class Io {
 	 * and exits the application with status code 1
 	 *
 	 * @link https://book.cakephp.org/4/en/console-commands/input-output.html#styling-output
+	 *
 	 * @param string $message The error message
 	 * @param int $exitCode The exit code for the shell task.
+	 *
 	 * @throws \Cake\Console\Exception\StopException
+	 *
 	 * @return void
 	 */
 	public function abort(string $message, int $exitCode = CommandInterface::CODE_ERROR): void {
@@ -201,6 +221,7 @@ class Io {
 	 *
 	 * @param string $name The name of the helper to render
 	 * @param array<string, mixed> $settings Configuration data for the helper.
+	 *
 	 * @return \Cake\Console\Helper The created helper instance.
 	 */
 	public function helper(string $name, array $settings = []): Helper {
@@ -219,6 +240,7 @@ class Io {
 	 * @param int $newlines Number of newlines to append.
 	 * @param int|null $size The number of bytes to overwrite. Defaults to the
 	 *    length of the last message output.
+	 *
 	 * @return void
 	 */
 	public function overwrite(array|string $message, int $newlines = 1, ?int $size = null): void {

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Controller\Admin;
 

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Controller\Admin;
 
@@ -35,7 +36,7 @@ class QueueController extends AppController {
 	 * Admin center.
 	 * Manage queues from admin backend (without the need to open ssh console window).
 	 *
-	 * @return \Cake\Http\Response|null|void
+	 * @return null|void
 	 */
 	public function index() {
 		$QueueProcesses = $this->fetchTable('Queue.QueueProcesses');
@@ -100,7 +101,7 @@ class QueueController extends AppController {
 	 * @throws \Cake\Http\Exception\NotFoundException
 	 * @return \Cake\Http\Response|null
 	 */
-	public function resetJob($id = null) {
+	public function resetJob(?int $id = null) {
 		$this->request->allowMethod('post');
 		if (!$id) {
 			throw new NotFoundException();
@@ -115,10 +116,9 @@ class QueueController extends AppController {
 
 	/**
 	 * @param int|null $id
-	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	public function removeJob($id = null) {
+	public function removeJob(?int $id = null) {
 		$this->request->allowMethod('post');
 		$queuedJob = $this->QueuedJobs->get($id);
 
@@ -202,10 +202,9 @@ class QueueController extends AppController {
 
 	/**
 	 * @param array<mixed>|string $default
-	 *
 	 * @return \Cake\Http\Response|null
 	 */
-	protected function refererRedirect($default) {
+	protected function refererRedirect(array|string $default) {
 		$url = $this->request->getQuery('redirect');
 		if (is_array($url)) {
 			throw new NotFoundException('Invalid array in query string');

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -36,7 +36,7 @@ class QueueController extends AppController {
 	 * Admin center.
 	 * Manage queues from admin backend (without the need to open ssh console window).
 	 *
-	 * @return null|void
+	 * @return \Cake\Http\Response|null|void
 	 */
 	public function index() {
 		$QueueProcesses = $this->fetchTable('Queue.QueueProcesses');

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -68,6 +68,7 @@ class QueueController extends AppController {
 
 	/**
 	 * @throws \Cake\Http\Exception\NotFoundException
+	 *
 	 * @return \Cake\Http\Response|null
 	 */
 	public function addJob() {
@@ -98,7 +99,9 @@ class QueueController extends AppController {
 
 	/**
 	 * @param int|null $id
+	 *
 	 * @throws \Cake\Http\Exception\NotFoundException
+	 *
 	 * @return \Cake\Http\Response|null
 	 */
 	public function resetJob(?int $id = null) {
@@ -116,6 +119,7 @@ class QueueController extends AppController {
 
 	/**
 	 * @param int|null $id
+	 *
 	 * @return \Cake\Http\Response|null
 	 */
 	public function removeJob(?int $id = null) {
@@ -202,6 +206,7 @@ class QueueController extends AppController {
 
 	/**
 	 * @param array<mixed>|string $default
+	 *
 	 * @return \Cake\Http\Response|null
 	 */
 	protected function refererRedirect(array|string $default) {

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Controller\Admin;
 
@@ -8,7 +9,6 @@ use Exception;
 
 /**
  * @property \Queue\Model\Table\QueueProcessesTable $QueueProcesses
- *
  * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueueProcess> paginate($object = null, array $settings = [])
  * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
  */
@@ -37,7 +37,7 @@ class QueueProcessesController extends AppController {
 	/**
 	 * Index method
 	 *
-	 * @return \Cake\Http\Response|null|void
+	 * @return null|void
 	 */
 	public function index() {
 		$queueProcesses = $this->paginate();
@@ -49,9 +49,9 @@ class QueueProcessesController extends AppController {
 	 * View method
 	 *
 	 * @param int|null $id Queue Process id.
-	 * @return \Cake\Http\Response|null|void
+	 * @return null|void
 	 */
-	public function view($id = null) {
+	public function view(?int $id = null) {
 		$queueProcess = $this->QueueProcesses->get($id, [
 			'contain' => [],
 		]);
@@ -65,7 +65,7 @@ class QueueProcessesController extends AppController {
 	 * @param int|null $id Queue Process id.
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
-	public function edit($id = null) {
+	public function edit(?int $id = null) {
 		$queueProcess = $this->QueueProcesses->get($id, [
 			'contain' => [],
 		]);
@@ -85,9 +85,9 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
-	 * @return \Cake\Http\Response|null|void Redirects to index.
+	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
-	public function terminate($id = null) {
+	public function terminate(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);
 
 		try {
@@ -104,9 +104,9 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
-	 * @return \Cake\Http\Response|null|void Redirects to index.
+	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
-	public function delete($id = null) {
+	public function delete(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);
 		$queueProcess = $this->QueueProcesses->get($id);
 
@@ -124,7 +124,7 @@ class QueueProcessesController extends AppController {
 	}
 
 	/**
-	 * @return \Cake\Http\Response|null|void Redirects to index.
+	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
 	public function cleanup() {
 		$this->request->allowMethod(['post', 'delete']);

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -49,6 +49,7 @@ class QueueProcessesController extends AppController {
 	 * View method
 	 *
 	 * @param int|null $id Queue Process id.
+	 *
 	 * @return null|void
 	 */
 	public function view(?int $id = null) {
@@ -63,6 +64,7 @@ class QueueProcessesController extends AppController {
 	 * Edit method
 	 *
 	 * @param int|null $id Queue Process id.
+	 *
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
 	public function edit(?int $id = null) {
@@ -85,6 +87,7 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
+	 *
 	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
 	public function terminate(?int $id = null) {
@@ -104,6 +107,7 @@ class QueueProcessesController extends AppController {
 
 	/**
 	 * @param int|null $id Queue Process id.
+	 *
 	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
 	public function delete(?int $id = null) {

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -37,7 +37,7 @@ class QueueProcessesController extends AppController {
 	/**
 	 * Index method
 	 *
-	 * @return null|void
+	 * @return \Cake\Http\Response|null|void
 	 */
 	public function index() {
 		$queueProcesses = $this->paginate();
@@ -50,7 +50,7 @@ class QueueProcessesController extends AppController {
 	 *
 	 * @param int|null $id Queue Process id.
 	 *
-	 * @return null|void
+	 * @return \Cake\Http\Response|null|void
 	 */
 	public function view(?int $id = null) {
 		$queueProcess = $this->QueueProcesses->get($id, [
@@ -88,7 +88,7 @@ class QueueProcessesController extends AppController {
 	/**
 	 * @param int|null $id Queue Process id.
 	 *
-	 * @return \Cake\Http\Response|null Redirects to index.
+	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
 	public function terminate(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);
@@ -108,7 +108,7 @@ class QueueProcessesController extends AppController {
 	/**
 	 * @param int|null $id Queue Process id.
 	 *
-	 * @return \Cake\Http\Response|null Redirects to index.
+	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
 	public function delete(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);
@@ -128,7 +128,7 @@ class QueueProcessesController extends AppController {
 	}
 
 	/**
-	 * @return \Cake\Http\Response|null Redirects to index.
+	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
 	public function cleanup() {
 		$this->request->allowMethod(['post', 'delete']);

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Controller\Admin;
 
@@ -13,7 +14,6 @@ use RuntimeException;
 
 /**
  * @property \Queue\Model\Table\QueuedJobsTable $QueuedJobs
- *
  * @method \Cake\Datasource\ResultSetInterface<\Queue\Model\Entity\QueuedJob> paginate($object = null, array $settings = [])
  * @property \Search\Controller\Component\SearchComponent $Search
  */
@@ -58,7 +58,7 @@ class QueuedJobsController extends AppController {
 	/**
 	 * Index method
 	 *
-	 * @return \Cake\Http\Response|null|void
+	 * @return null|void
 	 */
 	public function index() {
 		if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Search')) {
@@ -87,7 +87,7 @@ class QueuedJobsController extends AppController {
 	 * @throws \Cake\Http\Exception\NotFoundException
 	 * @return void
 	 */
-	public function stats($jobType = null) {
+	public function stats(?string $jobType = null): void {
 		if (!Configure::read('Queue.isStatisticEnabled')) {
 			throw new NotFoundException('Not enabled');
 		}
@@ -106,9 +106,9 @@ class QueuedJobsController extends AppController {
 	 * View method
 	 *
 	 * @param int|null $id Queued Job id.
-	 * @return \Cake\Http\Response|null|void
+	 * @return null|void
 	 */
-	public function view($id = null) {
+	public function view(?int $id = null) {
 		$queuedJob = $this->QueuedJobs->get((int)$id, [
 			'contain' => ['WorkerProcesses'],
 		]);
@@ -129,10 +129,9 @@ class QueuedJobsController extends AppController {
 	}
 
 	/**
-	   * @throws \RuntimeException
-	   *
-	   * @return \Cake\Http\Response|null|void
-	   */
+	 * @throws \RuntimeException
+	 * @return \Cake\Http\Response|null|void
+	 */
 	public function import() {
 		if ($this->request->is(['post'])) {
 			/** @var \Laminas\Diactoros\UploadedFile|null $file */
@@ -196,7 +195,7 @@ class QueuedJobsController extends AppController {
 	 * @param int|null $id Queued Job id.
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
-	public function edit($id = null) {
+	public function edit(?int $id = null) {
 		$queuedJob = $this->QueuedJobs->get($id, [
 			'contain' => [],
 		]);
@@ -224,7 +223,7 @@ class QueuedJobsController extends AppController {
 	 * @param int|null $id Queued Job id.
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
-	public function data($id = null) {
+	public function data(?int $id = null) {
 		return $this->edit($id);
 	}
 
@@ -232,9 +231,9 @@ class QueuedJobsController extends AppController {
 	 * Delete method
 	 *
 	 * @param int|null $id Queued Job id.
-	 * @return \Cake\Http\Response|null|void Redirects to index.
+	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
-	public function delete($id = null) {
+	public function delete(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);
 		$queuedJob = $this->QueuedJobs->get($id);
 		if ($this->QueuedJobs->delete($queuedJob)) {

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -58,7 +58,7 @@ class QueuedJobsController extends AppController {
 	/**
 	 * Index method
 	 *
-	 * @return null|void
+	 * @return \Cake\Http\Response|null|void
 	 */
 	public function index() {
 		if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Search')) {
@@ -109,7 +109,7 @@ class QueuedJobsController extends AppController {
 	 *
 	 * @param int|null $id Queued Job id.
 	 *
-	 * @return null|void
+	 * @return \Cake\Http\Response|null|void
 	 */
 	public function view(?int $id = null) {
 		$queuedJob = $this->QueuedJobs->get((int)$id, [
@@ -238,7 +238,7 @@ class QueuedJobsController extends AppController {
 	 *
 	 * @param int|null $id Queued Job id.
 	 *
-	 * @return \Cake\Http\Response|null Redirects to index.
+	 * @return \Cake\Http\Response|null|void Redirects to index.
 	 */
 	public function delete(?int $id = null) {
 		$this->request->allowMethod(['post', 'delete']);

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -84,7 +84,9 @@ class QueuedJobsController extends AppController {
 	 * Index method
 	 *
 	 * @param string|null $jobType
+	 *
 	 * @throws \Cake\Http\Exception\NotFoundException
+	 *
 	 * @return void
 	 */
 	public function stats(?string $jobType = null): void {
@@ -106,6 +108,7 @@ class QueuedJobsController extends AppController {
 	 * View method
 	 *
 	 * @param int|null $id Queued Job id.
+	 *
 	 * @return null|void
 	 */
 	public function view(?int $id = null) {
@@ -130,6 +133,7 @@ class QueuedJobsController extends AppController {
 
 	/**
 	 * @throws \RuntimeException
+	 *
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function import() {
@@ -193,6 +197,7 @@ class QueuedJobsController extends AppController {
 	 * Edit method
 	 *
 	 * @param int|null $id Queued Job id.
+	 *
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
 	public function edit(?int $id = null) {
@@ -221,6 +226,7 @@ class QueuedJobsController extends AppController {
 
 	/**
 	 * @param int|null $id Queued Job id.
+	 *
 	 * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
 	 */
 	public function data(?int $id = null) {
@@ -231,6 +237,7 @@ class QueuedJobsController extends AppController {
 	 * Delete method
 	 *
 	 * @param int|null $id Queued Job id.
+	 *
 	 * @return \Cake\Http\Response|null Redirects to index.
 	 */
 	public function delete(?int $id = null) {
@@ -247,6 +254,7 @@ class QueuedJobsController extends AppController {
 
 	/**
 	 * @throws \Cake\Http\Exception\NotFoundException
+	 *
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function execute() {

--- a/src/Generator/Task/QueuedJobTask.php
+++ b/src/Generator/Task/QueuedJobTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Generator\Task;
 

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author Mark Scherer
  * @license http://www.opensource.org/licenses/mit-license.php MIT License

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -21,6 +21,7 @@ class QueueTransport extends AbstractTransport {
 	 * Send mail
 	 *
 	 * @param \Cake\Mailer\Message $message
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function send(Message $message): array {

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -23,6 +23,7 @@ class SimpleQueueTransport extends AbstractTransport {
 	 * Send mail
 	 *
 	 * @param \Cake\Mailer\Message $message
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function send(Message $message): array {

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author Mark Scherer
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
@@ -9,6 +11,7 @@ namespace Queue\Mailer\Transport;
 use Cake\Mailer\AbstractTransport;
 use Cake\Mailer\Message;
 use Cake\ORM\TableRegistry;
+use Queue\Model\Table\QueuedJobsTable;
 
 /**
  * Send mail using Queue plugin and Message settings.
@@ -65,7 +68,7 @@ class SimpleQueueTransport extends AbstractTransport {
 	/**
 	 * @return \Queue\Model\Table\QueuedJobsTable
 	 */
-	protected function getQueuedJobsModel() {
+	protected function getQueuedJobsModel(): QueuedJobsTable {
 		/** @var \Queue\Model\Table\QueuedJobsTable $table */
 		$table = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
 

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -13,6 +13,7 @@ class OldTaskFinder {
 	 * Makes sure that app tasks are prioritized over plugin ones.
 	 *
 	 * @param string|null $plugin
+	 *
 	 * @return array<string>
 	 */
 	public function all(?string $plugin): array {
@@ -31,6 +32,7 @@ class OldTaskFinder {
 	/**
 	 * @param string $path
 	 * @param string|null $plugin
+	 *
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin): array {

--- a/src/Migration/OldTaskFinder.php
+++ b/src/Migration/OldTaskFinder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Migration;
 
@@ -12,10 +13,9 @@ class OldTaskFinder {
 	 * Makes sure that app tasks are prioritized over plugin ones.
 	 *
 	 * @param string|null $plugin
-	 *
 	 * @return array<string>
 	 */
-	public function all(?string $plugin) {
+	public function all(?string $plugin): array {
 		$paths = App::classPath('Shell/Task', $plugin);
 
 		$allTasks = [];
@@ -31,10 +31,9 @@ class OldTaskFinder {
 	/**
 	 * @param string $path
 	 * @param string|null $plugin
-	 *
 	 * @return array<string>
 	 */
-	protected function getTasks(string $path, ?string $plugin) {
+	protected function getTasks(string $path, ?string $plugin): array {
 		$res = glob($path . '*Task.php') ?: [];
 
 		$tasks = [];

--- a/src/Model/Entity/QueueProcess.php
+++ b/src/Model/Entity/QueueProcess.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Model\Entity;
 

--- a/src/Model/Entity/QueuedJob.php
+++ b/src/Model/Entity/QueuedJob.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Model\Entity;
 

--- a/src/Model/ProcessEndingException.php
+++ b/src/Model/ProcessEndingException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Model;
 

--- a/src/Model/QueueException.php
+++ b/src/Model/QueueException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Model;
 

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -51,6 +51,7 @@ class QueueProcessesTable extends Table {
 	 * Initialize method
 	 *
 	 * @param array<string, mixed> $config The configuration for the Table.
+	 *
 	 * @return void
 	 */
 	public function initialize(array $config): void {
@@ -77,6 +78,7 @@ class QueueProcessesTable extends Table {
 	 * Default validation rules.
 	 *
 	 * @param \Cake\Validation\Validator $validator Validator instance.
+	 *
 	 * @return \Cake\Validation\Validator
 	 */
 	public function validationDefault(Validator $validator): Validator {
@@ -105,6 +107,7 @@ class QueueProcessesTable extends Table {
 	/**
 	 * @param string $value
 	 * @param array<string, mixed> $context
+	 *
 	 * @return bool
 	 */
 	public function validateCount(string $value, array $context): bool {
@@ -134,6 +137,7 @@ class QueueProcessesTable extends Table {
 	/**
 	 * @param string $pid
 	 * @param string $key
+	 *
 	 * @return int
 	 */
 	public function add(string $pid, string $key): int {
@@ -151,7 +155,9 @@ class QueueProcessesTable extends Table {
 
 	/**
 	 * @param string $pid
+	 *
 	 * @throws \Queue\Model\ProcessEndingException
+	 *
 	 * @return void
 	 */
 	public function update(string $pid): void {
@@ -172,6 +178,7 @@ class QueueProcessesTable extends Table {
 
 	/**
 	 * @param string $pid
+	 *
 	 * @return void
 	 */
 	public function remove(string $pid): void {
@@ -232,6 +239,7 @@ class QueueProcessesTable extends Table {
 	 * $forThisServer only works for DB approach.
 	 *
 	 * @param bool $forThisServer
+	 *
 	 * @return array<\Queue\Model\Entity\QueueProcess>
 	 */
 	public function getProcesses(bool $forThisServer = false): array {
@@ -255,6 +263,7 @@ class QueueProcessesTable extends Table {
 	 * Soft ending of a running job, e.g. when migration is starting
 	 *
 	 * @param string $pid
+	 *
 	 * @return void
 	 */
 	public function endProcess(string $pid): void {
@@ -274,6 +283,7 @@ class QueueProcessesTable extends Table {
 	 *
 	 * @param string $pid
 	 * @param int $sig Signal (defaults to graceful SIGTERM = 15)
+	 *
 	 * @return void
 	 */
 	public function terminateProcess(string $pid, int $sig = SIGTERM): void {

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Model\Table;
 
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
@@ -20,7 +22,6 @@ use Queue\Queue\Config;
  * @method \Queue\Model\Entity\QueueProcess patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
  * @method array<\Queue\Model\Entity\QueueProcess> patchEntities(iterable $entities, array $data, array $options = [])
  * @method \Queue\Model\Entity\QueueProcess findOrCreate($search, ?callable $callback = null, $options = [])
- *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @method \Queue\Model\Entity\QueueProcess saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
  * @method \Queue\Model\Entity\QueueProcess newEmptyEntity()
@@ -104,10 +105,9 @@ class QueueProcessesTable extends Table {
 	/**
 	 * @param string $value
 	 * @param array<string, mixed> $context
-	 *
 	 * @return bool
 	 */
-	public function validateCount($value, array $context): bool {
+	public function validateCount(string $value, array $context): bool {
 		$maxWorkers = Config::maxworkers();
 		if (!$value || !$maxWorkers) {
 			return true;
@@ -124,7 +124,7 @@ class QueueProcessesTable extends Table {
 	/**
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
-	public function findActive() {
+	public function findActive(): SelectQuery {
 		$timeout = Config::defaultworkertimeout();
 		$thresholdTime = (new DateTime())->subSeconds($timeout);
 
@@ -134,7 +134,6 @@ class QueueProcessesTable extends Table {
 	/**
 	 * @param string $pid
 	 * @param string $key
-	 *
 	 * @return int
 	 */
 	public function add(string $pid, string $key): int {
@@ -173,7 +172,6 @@ class QueueProcessesTable extends Table {
 
 	/**
 	 * @param string $pid
-	 *
 	 * @return void
 	 */
 	public function remove(string $pid): void {

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -105,6 +105,7 @@ class QueuedJobsTable extends Table {
 	 * initialize Table
 	 *
 	 * @param array<string, mixed> $config Configuration
+	 *
 	 * @return void
 	 */
 	public function initialize(array $config): void {
@@ -128,6 +129,7 @@ class QueuedJobsTable extends Table {
 	 * @param \Cake\Event\EventInterface $event
 	 * @param \ArrayObject<string, mixed> $data
 	 * @param \ArrayObject<string, mixed> $options
+	 *
 	 * @return void
 	 */
 	public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {
@@ -169,6 +171,7 @@ class QueuedJobsTable extends Table {
 	 * Default validation rules.
 	 *
 	 * @param \Cake\Validation\Validator $validator Validator instance.
+	 *
 	 * @return \Cake\Validation\Validator
 	 */
 	public function validationDefault(Validator $validator): Validator {
@@ -200,6 +203,7 @@ class QueuedJobsTable extends Table {
 	 * @param string $jobTask Job task name or FQCN
 	 * @param array<string, mixed>|null $data Array of data
 	 * @param array<string, mixed> $config Config to save along with the job
+	 *
 	 * @return \Queue\Model\Entity\QueuedJob Saved job entity
 	 */
 	public function createJob(string $jobTask, ?array $data = null, array $config = []): QueuedJob {
@@ -217,6 +221,7 @@ class QueuedJobsTable extends Table {
 
 	/**
 	 * @param class-string<\Queue\Queue\Task>|string $jobType
+	 *
 	 * @return string
 	 */
 	protected function jobTask(string $jobType): string {
@@ -230,7 +235,9 @@ class QueuedJobsTable extends Table {
 	/**
 	 * @param string $reference
 	 * @param string|null $jobTask
+	 *
 	 * @throws \InvalidArgumentException
+	 *
 	 * @return bool
 	 */
 	public function isQueued(string $reference, ?string $jobTask = null): bool {
@@ -254,6 +261,7 @@ class QueuedJobsTable extends Table {
 	 * Either returns the number of ALL pending jobs, or the number of pending jobs of the passed type.
 	 *
 	 * @param string|null $type Job type to Count
+	 *
 	 * @return int
 	 */
 	public function getLength(?string $type = null): int {
@@ -294,6 +302,7 @@ class QueuedJobsTable extends Table {
 	 * TO-DO: rewrite as virtual field
 	 *
 	 * @param bool $disableHydration
+	 *
 	 * @return array<\Queue\Model\Entity\QueuedJob>|array<mixed>
 	 */
 	public function getStats(bool $disableHydration = false): array {
@@ -365,6 +374,7 @@ class QueuedJobsTable extends Table {
 	 * ]
 	 *
 	 * @param string|null $jobTask
+	 *
 	 * @return array<string, array<string, mixed>>
 	 */
 	public function getFullStats(?string $jobTask = null): array {
@@ -460,6 +470,7 @@ class QueuedJobsTable extends Table {
 	 * @param array<string, array<string, mixed>> $tasks Available QueueWorkerTasks.
 	 * @param array<string> $groups Request a job from these groups (or exclude certain groups), or any otherwise.
 	 * @param array<string> $types Request a job from these types (or exclude certain types), or any otherwise.
+	 *
 	 * @return \Queue\Model\Entity\QueuedJob|null
 	 */
 	public function requestJob(array $tasks, array $groups = [], array $types = []): ?QueuedJob {
@@ -658,6 +669,7 @@ class QueuedJobsTable extends Table {
 	 * @param int $id ID of job
 	 * @param float $progress Value from 0 to 1
 	 * @param string|null $status
+	 *
 	 * @return bool Success
 	 */
 	public function updateProgress(int $id, float $progress, ?string $status = null): bool {
@@ -679,6 +691,7 @@ class QueuedJobsTable extends Table {
 	 * Mark a job as Completed, removing it from the queue.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $job Job
+	 *
 	 * @return bool Success
 	 */
 	public function markJobDone(QueuedJob $job): bool {
@@ -696,6 +709,7 @@ class QueuedJobsTable extends Table {
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $job Job
 	 * @param string|null $failureMessage Optional message to append to the failure_message field.
+	 *
 	 * @return bool Success
 	 */
 	public function markJobFailed(QueuedJob $job, ?string $failureMessage = null): bool {
@@ -730,6 +744,7 @@ class QueuedJobsTable extends Table {
 	 *
 	 * @param int|null $id
 	 * @param bool $full Also currently running jobs.
+	 *
 	 * @return int Success
 	 */
 	public function reset(?int $id = null, bool $full = false): int {
@@ -757,6 +772,7 @@ class QueuedJobsTable extends Table {
 	/**
 	 * @param string $task
 	 * @param string|null $reference
+	 *
 	 * @return int
 	 */
 	public function rerunByTask(string $task, ?string $reference = null): int {
@@ -781,6 +797,7 @@ class QueuedJobsTable extends Table {
 
 	/**
 	 * @param int $id
+	 *
 	 * @return int
 	 */
 	public function rerun(int $id): int {
@@ -846,6 +863,7 @@ class QueuedJobsTable extends Table {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedTask
 	 * @param array<string, array<string, mixed>> $taskConfiguration
+	 *
 	 * @return string
 	 */
 	public function getFailedStatus(QueuedJob $queuedTask, array $taskConfiguration): string {
@@ -868,6 +886,7 @@ class QueuedJobsTable extends Table {
 	 *
 	 * @param \Cake\ORM\Query\SelectQuery $query The query to find with
 	 * @param array<string, mixed> $options The options to find with
+	 *
 	 * @return \Cake\ORM\Query\SelectQuery The query builder
 	 */
 	public function findQueued(SelectQuery $query, array $options): SelectQuery {
@@ -955,6 +974,7 @@ class QueuedJobsTable extends Table {
 	 * @param array<mixed> $conditions
 	 * @param string $key
 	 * @param array<string> $values
+	 *
 	 * @return array<mixed>
 	 */
 	protected function addFilter(array $conditions, string $key, array $values): array {
@@ -984,6 +1004,7 @@ class QueuedJobsTable extends Table {
 	 * Without argument this will be "now".
 	 *
 	 * @param \Cake\I18n\DateTime|string|int|null $notBefore
+	 *
 	 * @return \Cake\I18n\DateTime
 	 */
 	protected function getDateTime(DateTime|string|int|null $notBefore = null): DateTime {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,6 +30,7 @@ class Plugin extends BasePlugin {
 	 * Console hook
 	 *
 	 * @param \Cake\Console\CommandCollection $commands The command collection
+	 *
 	 * @return \Cake\Console\CommandCollection
 	 */
 	public function console(CommandCollection $commands): CommandCollection {
@@ -50,6 +51,7 @@ class Plugin extends BasePlugin {
 
 	/**
 	 * @param \Cake\Routing\RouteBuilder $routes The route builder to update.
+	 *
 	 * @return void
 	 */
 	public function routes(RouteBuilder $routes): void {
@@ -68,6 +70,7 @@ class Plugin extends BasePlugin {
 
 	/**
 	 * @param \Cake\Core\ContainerInterface $container The DI container instance
+	 *
 	 * @return void
 	 */
 	public function services(ContainerInterface $container): void {

--- a/src/Queue/AddFromBackendInterface.php
+++ b/src/Queue/AddFromBackendInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 

--- a/src/Queue/AddInterface.php
+++ b/src/Queue/AddInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 
@@ -16,7 +17,6 @@ interface AddInterface {
 	 * Will create one example job in the queue, which later will be executed using run().
 	 *
 	 * @param string|null $data Optional data for the task, make sure to "quote multi words"
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void;

--- a/src/Queue/AddInterface.php
+++ b/src/Queue/AddInterface.php
@@ -17,6 +17,7 @@ interface AddInterface {
 	 * Will create one example job in the queue, which later will be executed using run().
 	 *
 	 * @param string|null $data Optional data for the task, make sure to "quote multi words"
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void;

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 
@@ -14,7 +15,7 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public static function defaultworkertimeout() {
+	public static function defaultworkertimeout(): int {
 		return Configure::read('Queue.defaultworkertimeout', 600); // 10min
 	}
 
@@ -23,7 +24,7 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public static function workermaxruntime() {
+	public static function workermaxruntime(): int {
 		return Configure::read('Queue.workermaxruntime', 120);
 	}
 
@@ -32,35 +33,35 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public static function cleanuptimeout() {
+	public static function cleanuptimeout(): int {
 		return Configure::read('Queue.cleanuptimeout', 2592000); // 30 days
 	}
 
 	/**
 	 * @return int
 	 */
-	public static function sleeptime() {
+	public static function sleeptime(): int {
 		return Configure::read('Queue.sleeptime', 10);
 	}
 
 	/**
 	 * @return int
 	 */
-	public static function gcprob() {
+	public static function gcprob(): int {
 		return Configure::read('Queue.gcprob', 10);
 	}
 
 	/**
 	 * @return int
 	 */
-	public static function defaultworkerretries() {
+	public static function defaultworkerretries(): int {
 		return Configure::read('Queue.defaultworkerretries', 1);
 	}
 
 	/**
 	 * @return int
 	 */
-	public static function maxworkers() {
+	public static function maxworkers(): int {
 		return Configure::read('Queue.maxworkers', 1);
 	}
 
@@ -78,7 +79,6 @@ class Config {
 
 	/**
 	 * @param array<string> $tasks
-	 *
 	 * @throws \RuntimeException
 	 * @return array<string, array<string, mixed>>
 	 */
@@ -108,9 +108,7 @@ class Config {
 
 	/**
 	 * @phpstan-param class-string<\Queue\Queue\Task>|string $class
-	 *
 	 * @param string $class
-	 *
 	 * @return string
 	 */
 	public static function taskName(string $class): string {

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -79,7 +79,9 @@ class Config {
 
 	/**
 	 * @param array<string> $tasks
+	 *
 	 * @throws \RuntimeException
+	 *
 	 * @return array<string, array<string, mixed>>
 	 */
 	public static function taskConfig(array $tasks): array {
@@ -108,7 +110,9 @@ class Config {
 
 	/**
 	 * @phpstan-param class-string<\Queue\Queue\Task>|string $class
+	 *
 	 * @param string $class
+	 *
 	 * @return string
 	 */
 	public static function taskName(string $class): string {

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -92,6 +92,7 @@ class Processor {
 
 	/**
 	 * @param array<string, mixed> $args
+	 *
 	 * @return int
 	 */
 	public function run(array $args): int {
@@ -192,6 +193,7 @@ class Processor {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param string $pid
+	 *
 	 * @return void
 	 */
 	protected function runJob(QueuedJob $queuedJob, string $pid): void {
@@ -241,6 +243,7 @@ class Processor {
 	 * @param string $message Log type
 	 * @param string|null $pid PID of the process
 	 * @param bool $addDetails
+	 *
 	 * @return void
 	 */
 	protected function log(string $message, ?string $pid = null, bool $addDetails = true): void {
@@ -263,6 +266,7 @@ class Processor {
 	/**
 	 * @param string $message
 	 * @param string|null $pid PID of the process
+	 *
 	 * @return void
 	 */
 	protected function logError(string $message, ?string $pid = null): void {
@@ -299,6 +303,7 @@ class Processor {
 	 * Signal handling to queue worker for clean shutdown
 	 *
 	 * @param int $signal
+	 *
 	 * @return void
 	 */
 	protected function exit(int $signal): void {
@@ -309,6 +314,7 @@ class Processor {
 	 * Signal handling for Ctrl+C
 	 *
 	 * @param int $signal
+	 *
 	 * @return void
 	 */
 	protected function abort(int $signal = 1): void {
@@ -345,6 +351,7 @@ class Processor {
 
 	/**
 	 * @param string $pid
+	 *
 	 * @return void
 	 */
 	protected function updatePid(string $pid): void {
@@ -367,6 +374,7 @@ class Processor {
 
 	/**
 	 * @param string|null $pid
+	 *
 	 * @return void
 	 */
 	protected function deletePid(?string $pid): void {
@@ -392,6 +400,7 @@ class Processor {
 
 	/**
 	 * @param int|null $providedTime
+	 *
 	 * @return int
 	 */
 	protected function time(?int $providedTime = null): int {
@@ -404,6 +413,7 @@ class Processor {
 
 	/**
 	 * @param string $param
+	 *
 	 * @return array<string>
 	 */
 	protected function stringToArray(string $param): array {
@@ -433,6 +443,7 @@ class Processor {
 
 	/**
 	 * @param array<string, mixed> $args
+	 *
 	 * @return array<string, mixed>
 	 */
 	protected function getConfig(array $args): array {
@@ -456,6 +467,7 @@ class Processor {
 
 	/**
 	 * @param string $taskName
+	 *
 	 * @return \Queue\Queue\TaskInterface
 	 */
 	protected function loadTask(string $taskName): TaskInterface {
@@ -471,7 +483,9 @@ class Processor {
 
 	/**
 	 * @psalm-return class-string<\Queue\Queue\Task>
+	 *
 	 * @param string $taskName
+	 *
 	 * @return string
 	 */
 	protected function getTaskClass(string $taskName): string {

--- a/src/Queue/ServicesTrait.php
+++ b/src/Queue/ServicesTrait.php
@@ -14,8 +14,10 @@ trait ServicesTrait {
 
 	/**
 	 * @param string $id Classname or identifier of the service you want to retrieve
+	 *
 	 * @throws \Psr\Container\NotFoundExceptionInterface
 	 * @throws \Psr\Container\ContainerExceptionInterface
+	 *
 	 * @return mixed
 	 */
 	protected function getService(string $id): mixed {
@@ -24,6 +26,7 @@ trait ServicesTrait {
 
 	/**
 	 * @param \Cake\Core\ContainerInterface $container
+	 *
 	 * @return void
 	 */
 	public function setContainer(ContainerInterface $container): void {

--- a/src/Queue/ServicesTrait.php
+++ b/src/Queue/ServicesTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 
@@ -9,7 +10,7 @@ trait ServicesTrait {
 	/**
 	 * @var \Cake\Core\ContainerInterface
 	 */
-	protected $container;
+	protected ContainerInterface $container;
 
 	/**
 	 * @param string $id Classname or identifier of the service you want to retrieve
@@ -17,7 +18,7 @@ trait ServicesTrait {
 	 * @throws \Psr\Container\ContainerExceptionInterface
 	 * @return mixed
 	 */
-	protected function getService(string $id) {
+	protected function getService(string $id): mixed {
 		return $this->container->get($id);
 	}
 
@@ -25,7 +26,7 @@ trait ServicesTrait {
 	 * @param \Cake\Core\ContainerInterface $container
 	 * @return void
 	 */
-	public function setContainer(ContainerInterface $container) {
+	public function setContainer(ContainerInterface $container): void {
 		$this->container = $container;
 	}
 

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -105,6 +105,7 @@ abstract class Task implements TaskInterface {
 
 	/**
 	 * @throws \InvalidArgumentException
+	 *
 	 * @return string
 	 */
 	public static function taskName(): string {

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author Andy Carter
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
@@ -10,6 +12,7 @@ use Cake\Console\ConsoleIo;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Psr\Log\LoggerInterface;
 use Queue\Console\Io;
+use Queue\Model\Table\QueuedJobsTable;
 
 /**
  * Queue Task.
@@ -21,15 +24,9 @@ abstract class Task implements TaskInterface {
 
 	use LocatorAwareTrait;
 
-	/**
-	 * @var string
-	 */
-	public $queueModelClass = 'Queue.QueuedJobs';
+	public string $queueModelClass = 'Queue.QueuedJobs';
 
-	/**
-	 * @var \Queue\Model\Table\QueuedJobsTable
-	 */
-	public $QueuedJobs;
+	public QueuedJobsTable $QueuedJobs;
 
 	/**
 	 * Timeout in seconds, after which the Task is reassigned to a new worker
@@ -39,7 +36,7 @@ abstract class Task implements TaskInterface {
 	 *
 	 * @var int|null
 	 */
-	public $timeout;
+	public ?int $timeout = null;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
@@ -47,7 +44,7 @@ abstract class Task implements TaskInterface {
 	 *
 	 * @var int|null
 	 */
-	public $retries;
+	public ?int $retries = null;
 
 	/**
 	 * Rate limiting per worker in seconds.
@@ -55,7 +52,7 @@ abstract class Task implements TaskInterface {
 	 *
 	 * @var int
 	 */
-	public $rate = 0;
+	public int $rate = 0;
 
 	/**
 	 * Activate this if you want cost management per server to avoid server overloading.
@@ -66,7 +63,7 @@ abstract class Task implements TaskInterface {
 	 *
 	 * @var int
 	 */
-	public $costs = 0;
+	public int $costs = 0;
 
 	/**
 	 * Set to true if you want to make sure this specific task is never run in parallel, neither
@@ -75,17 +72,17 @@ abstract class Task implements TaskInterface {
 	 *
 	 * @var bool
 	 */
-	public $unique = false;
+	public bool $unique = false;
 
 	/**
 	 * @var \Queue\Console\Io
 	 */
-	protected $io;
+	protected Io $io;
 
 	/**
 	 * @var \Psr\Log\LoggerInterface|null
 	 */
-	protected $logger;
+	protected ?LoggerInterface $logger = null;
 
 	/**
 	 * @param \Queue\Console\Io|null $io IO

--- a/src/Queue/Task/CostsExampleTask.php
+++ b/src/Queue/Task/CostsExampleTask.php
@@ -27,6 +27,7 @@ class CostsExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * - bin/cake queue add Queue.CostsExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -53,6 +54,7 @@ class CostsExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {
@@ -67,6 +69,7 @@ class CostsExampleTask extends Task implements AddInterface, AddFromBackendInter
 
 	/**
 	 * @param int $seconds
+	 *
 	 * @return void
 	 */
 	public function setSleep(int $seconds): void {

--- a/src/Queue/Task/CostsExampleTask.php
+++ b/src/Queue/Task/CostsExampleTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
@@ -14,19 +15,18 @@ class CostsExampleTask extends Task implements AddInterface, AddFromBackendInter
 	/**
 	 * @var int
 	 */
-	public $costs = 55;
+	public int $costs = 55;
 
 	/**
 	 * @var int
 	 */
-	protected $sleep = 10;
+	protected int $sleep = 10;
 
 	/**
 	 * To invoke from CLI execute:
 	 * - bin/cake queue add Queue.CostsExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -56,6 +56,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 	 * "Add" the task, not possible for EmailTask without adminEmail configured.
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -94,8 +95,10 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 	/**
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @throws \Queue\Model\QueueException
 	 * @throws \Throwable
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {
@@ -170,6 +173,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 	 * Check if Mail class exists and create instance
 	 *
 	 * @throws \Queue\Model\QueueException
+	 *
 	 * @return \Cake\Mailer\Mailer
 	 */
 	protected function getMailer(): Mailer {

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -1,9 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
 use Cake\Core\Configure;
 use Cake\Log\Log;
+use Cake\Mailer\Mailer;
 use Cake\Mailer\Message;
 use Cake\Mailer\TransportFactory;
 use Psr\Log\LoggerInterface;
@@ -26,15 +28,9 @@ use Throwable;
  */
 class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 
-	/**
-	 * @var int
-	 */
-	public $timeout = 60;
+	public ?int $timeout = 60;
 
-	/**
-	 * @var \Cake\Mailer\Mailer
-	 */
-	public $mailer;
+	public Mailer $mailer;
 
 	/**
 	 * List of default variables for Email class.
@@ -60,7 +56,6 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 	 * "Add" the task, not possible for EmailTask without adminEmail configured.
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -177,7 +172,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 	 * @throws \Queue\Model\QueueException
 	 * @return \Cake\Mailer\Mailer
 	 */
-	protected function getMailer() {
+	protected function getMailer(): Mailer {
 		/** @phpstan-var class-string<\Cake\Mailer\Mailer> $class */
 		$class = Configure::read('Queue.mailerClass');
 		if (!$class) {

--- a/src/Queue/Task/ExampleTask.php
+++ b/src/Queue/Task/ExampleTask.php
@@ -30,6 +30,7 @@ class ExampleTask extends Task implements AddInterface, AddFromBackendInterface 
 	 * - bin/cake queue add Queue.Example
 	 *
 	 * @param string|null $data Optional data for the task, make sure to "quote multi words"
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -57,6 +58,7 @@ class ExampleTask extends Task implements AddInterface, AddFromBackendInterface 
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/ExampleTask.php
+++ b/src/Queue/Task/ExampleTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
@@ -17,10 +19,8 @@ class ExampleTask extends Task implements AddInterface, AddFromBackendInterface 
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Example add functionality.
@@ -30,7 +30,6 @@ class ExampleTask extends Task implements AddInterface, AddFromBackendInterface 
 	 * - bin/cake queue add Queue.Example
 	 *
 	 * @param string|null $data Optional data for the task, make sure to "quote multi words"
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/ExceptionExampleTask.php
+++ b/src/Queue/Task/ExceptionExampleTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
@@ -14,10 +15,8 @@ class ExceptionExampleTask extends Task implements AddInterface, AddFromBackendI
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Example add functionality.
@@ -27,7 +26,6 @@ class ExceptionExampleTask extends Task implements AddInterface, AddFromBackendI
 	 * - bin/cake queue add Queue.ExceptionExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/ExceptionExampleTask.php
+++ b/src/Queue/Task/ExceptionExampleTask.php
@@ -26,6 +26,7 @@ class ExceptionExampleTask extends Task implements AddInterface, AddFromBackendI
 	 * - bin/cake queue add Queue.ExceptionExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -53,7 +54,9 @@ class ExceptionExampleTask extends Task implements AddInterface, AddFromBackendI
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @throws \Queue\Model\QueueException
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/ExecuteTask.php
+++ b/src/Queue/Task/ExecuteTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
@@ -27,7 +29,6 @@ class ExecuteTask extends Task implements AddInterface {
 	 * Will create one example job in the queue, which later will be executed using run();
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/ExecuteTask.php
+++ b/src/Queue/Task/ExecuteTask.php
@@ -29,6 +29,7 @@ class ExecuteTask extends Task implements AddInterface {
 	 * Will create one example job in the queue, which later will be executed using run();
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -69,7 +70,9 @@ class ExecuteTask extends Task implements AddInterface {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @throws \Queue\Model\QueueException
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/MailerTask.php
+++ b/src/Queue/Task/MailerTask.php
@@ -33,9 +33,11 @@ class MailerTask extends Task {
 	/**
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @throws \Queue\Model\QueueException
 	 * @throws \Cake\Mailer\Exception\MissingMailerException
 	 * @throws \Throwable
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/MailerTask.php
+++ b/src/Queue/Task/MailerTask.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
 use Cake\Log\Log;
+use Cake\Mailer\Mailer;
 use Cake\Mailer\MailerAwareTrait;
 use Queue\Model\QueueException;
 use Queue\Queue\Task;
@@ -21,15 +23,12 @@ class MailerTask extends Task {
 
 	use MailerAwareTrait;
 
-	/**
-	 * @var int
-	 */
-	public $timeout = 60;
+	public ?int $timeout = 60;
 
 	/**
 	 * @var \Cake\Mailer\Mailer
 	 */
-	protected $mailer;
+	protected Mailer $mailer;
 
 	/**
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()

--- a/src/Queue/Task/MonitorExampleTask.php
+++ b/src/Queue/Task/MonitorExampleTask.php
@@ -32,6 +32,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	 * - bin/cake queue add Queue.MonitorExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -58,6 +59,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/MonitorExampleTask.php
+++ b/src/Queue/Task/MonitorExampleTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
  */
@@ -19,10 +21,8 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * MonitorExample add functionality.
@@ -32,7 +32,6 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	 * - bin/cake queue add Queue.MonitorExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -74,7 +73,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	/**
 	 * @return void
 	 */
-	protected function doMonitoring() {
+	protected function doMonitoring(): void {
 		$memory = $this->getSystemMemInfo();
 
 		$array = [
@@ -90,7 +89,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	/**
 	 * @return array<string>
 	 */
-	protected function getSystemMemInfo() {
+	protected function getSystemMemInfo(): array {
 		$data = explode("\n", file_get_contents('/proc/meminfo') ?: '');
 		$meminfo = [];
 		foreach ($data as $line) {

--- a/src/Queue/Task/ProgressExampleTask.php
+++ b/src/Queue/Task/ProgressExampleTask.php
@@ -30,6 +30,7 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 	 * - bin/cake queue add Queue.ProgressExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -62,6 +63,7 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/ProgressExampleTask.php
+++ b/src/Queue/Task/ProgressExampleTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
@@ -13,10 +14,8 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 120;
+	public ?int $timeout = 120;
 
 	/**
 	 * @var int
@@ -31,7 +30,6 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 	 * - bin/cake queue add Queue.ProgressExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/RetryExampleTask.php
+++ b/src/Queue/Task/RetryExampleTask.php
@@ -37,6 +37,7 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * This is only for demo/testing purposes.
 	 *
 	 * @throws \RuntimeException
+	 *
 	 * @return bool
 	 */
 	public static function init(): bool {
@@ -61,6 +62,7 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * - bin/cake queue add Queue.RetryExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -93,6 +95,7 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/RetryExampleTask.php
+++ b/src/Queue/Task/RetryExampleTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
@@ -18,28 +20,23 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
-	 *
-	 * @var int
 	 */
-	public $retries = 4;
+	public ?int $retries = 4;
 
 	/**
 	 * @var string
 	 */
-	protected static $file = TMP . 'task_retry.txt';
+	protected static string $file = TMP . 'task_retry.txt';
 
 	/**
 	 * This is only for demo/testing purposes.
 	 *
 	 * @throws \RuntimeException
-	 *
 	 * @return bool
 	 */
 	public static function init(): bool {
@@ -64,7 +61,6 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * - bin/cake queue add Queue.RetryExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/SuperExampleTask.php
+++ b/src/Queue/Task/SuperExampleTask.php
@@ -30,6 +30,7 @@ class SuperExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * - bin/cake queue add Queue.SuperExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -58,6 +59,7 @@ class SuperExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/src/Queue/Task/SuperExampleTask.php
+++ b/src/Queue/Task/SuperExampleTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License
@@ -17,10 +19,8 @@ class SuperExampleTask extends Task implements AddInterface, AddFromBackendInter
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * SuperExample add functionality.
@@ -30,7 +30,6 @@ class SuperExampleTask extends Task implements AddInterface, AddFromBackendInter
 	 * - bin/cake queue add Queue.SuperExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/Task/UniqueExampleTask.php
+++ b/src/Queue/Task/UniqueExampleTask.php
@@ -27,6 +27,7 @@ class UniqueExampleTask extends Task implements AddInterface, AddFromBackendInte
 	 * - bin/cake queue add Queue.UniqueExample
 	 *
 	 * @param string|null $data
+	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {
@@ -54,6 +55,7 @@ class UniqueExampleTask extends Task implements AddInterface, AddFromBackendInte
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {
@@ -68,6 +70,7 @@ class UniqueExampleTask extends Task implements AddInterface, AddFromBackendInte
 
 	/**
 	 * @param int $seconds
+	 *
 	 * @return void
 	 */
 	public function setSleep(int $seconds): void {

--- a/src/Queue/Task/UniqueExampleTask.php
+++ b/src/Queue/Task/UniqueExampleTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue\Task;
 
@@ -14,19 +15,18 @@ class UniqueExampleTask extends Task implements AddInterface, AddFromBackendInte
 	/**
 	 * @var int
 	 */
-	protected $sleep = 10;
+	protected int $sleep = 10;
 
 	/**
 	 * @var bool
 	 */
-	public $unique = true;
+	public bool $unique = true;
 
 	/**
 	 * To invoke from CLI execute:
 	 * - bin/cake queue add Queue.UniqueExample
 	 *
 	 * @param string|null $data
-	 *
 	 * @return void
 	 */
 	public function add(?string $data): void {

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 
@@ -15,16 +16,13 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-var array<string, class-string<\Queue\Queue\Task>>|null
-	 *
 	 * @var array<string>|null
 	 */
-	protected $tasks;
+	protected ?array $tasks = null;
 
 	/**
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
-	 *
 	 * @param string $type Type of interface.
-	 *
 	 * @return array<string>
 	 */
 	public function allAddable(string $type = AddInterface::class): array {
@@ -44,7 +42,6 @@ class TaskFinder {
 	 * Makes sure that app tasks are prioritized over plugin ones.
 	 *
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
-	 *
 	 * @return array<string>
 	 */
 	public function all(): array {
@@ -73,10 +70,8 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
-	 *
 	 * @param string $path
 	 * @param string|null $plugin
-	 *
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin = null): array {
@@ -122,7 +117,6 @@ class TaskFinder {
 	 * Resolves FQCN to a task name.
 	 *
 	 * @param class-string<\Queue\Queue\Task>|string $jobTask
-	 *
 	 * @return string
 	 */
 	public function resolve(string $jobTask): string {
@@ -162,9 +156,7 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-return class-string<\Queue\Queue\Task>
-	 *
 	 * @param string $name
-	 *
 	 * @return string
 	 */
 	public function getClass(string $name): string {

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -22,7 +22,9 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
+	 *
 	 * @param string $type Type of interface.
+	 *
 	 * @return array<string>
 	 */
 	public function allAddable(string $type = AddInterface::class): array {
@@ -42,6 +44,7 @@ class TaskFinder {
 	 * Makes sure that app tasks are prioritized over plugin ones.
 	 *
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
+	 *
 	 * @return array<string>
 	 */
 	public function all(): array {
@@ -70,8 +73,10 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-return array<string, class-string<\Queue\Queue\Task>>
+	 *
 	 * @param string $path
 	 * @param string|null $plugin
+	 *
 	 * @return array<string>
 	 */
 	protected function getTasks(string $path, ?string $plugin = null): array {
@@ -117,6 +122,7 @@ class TaskFinder {
 	 * Resolves FQCN to a task name.
 	 *
 	 * @param class-string<\Queue\Queue\Task>|string $jobTask
+	 *
 	 * @return string
 	 */
 	public function resolve(string $jobTask): string {
@@ -156,7 +162,9 @@ class TaskFinder {
 
 	/**
 	 * @phpstan-return class-string<\Queue\Queue\Task>
+	 *
 	 * @param string $name
+	 *
 	 * @return string
 	 */
 	public function getClass(string $name): string {

--- a/src/Queue/TaskInterface.php
+++ b/src/Queue/TaskInterface.php
@@ -19,6 +19,7 @@ interface TaskInterface {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void;

--- a/src/Queue/TaskInterface.php
+++ b/src/Queue/TaskInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Queue;
 

--- a/src/Utility/JsonSerializer.php
+++ b/src/Utility/JsonSerializer.php
@@ -20,6 +20,7 @@ class JsonSerializer implements SerializerInterface {
 	 *
 	 * @param array<string, mixed> $data
 	 * @param array<string, mixed> $options Options normalizers/encoders have access to
+	 *
 	 * @return string
 	 */
 	public function serialize(array $data, array $options = []): string {
@@ -34,6 +35,7 @@ class JsonSerializer implements SerializerInterface {
 	 *
 	 * @param string $data
 	 * @param array<string, mixed> $options
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function deserialize(string $data, array $options = []): array {

--- a/src/Utility/JsonSerializer.php
+++ b/src/Utility/JsonSerializer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Utility;
 

--- a/src/Utility/ObjectSerializer.php
+++ b/src/Utility/ObjectSerializer.php
@@ -10,6 +10,7 @@ class ObjectSerializer implements SerializerInterface {
 	 *
 	 * @param array<string, mixed> $data
 	 * @param array<string, mixed> $options Options normalizers/encoders have access to
+	 *
 	 * @return string
 	 */
 	public function serialize(array $data, array $options = []): string {
@@ -21,6 +22,7 @@ class ObjectSerializer implements SerializerInterface {
 	 *
 	 * @param string $data
 	 * @param array<string, mixed> $options
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function deserialize(string $data, array $options = []): array {

--- a/src/Utility/ObjectSerializer.php
+++ b/src/Utility/ObjectSerializer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Utility;
 

--- a/src/Utility/Serializer.php
+++ b/src/Utility/Serializer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Utility;
 

--- a/src/Utility/Serializer.php
+++ b/src/Utility/Serializer.php
@@ -12,6 +12,7 @@ class Serializer {
 	 *
 	 * @param array<string, mixed> $data
 	 * @param array<string, mixed> $options Options normalizers/encoders have access to
+	 *
 	 * @return string
 	 */
 	public static function serialize(array $data, array $options = []): string {
@@ -25,6 +26,7 @@ class Serializer {
 	 *
 	 * @param string $data
 	 * @param array<string, mixed> $options
+	 *
 	 * @return array<string, mixed>
 	 */
 	public static function deserialize(string $data, array $options = []): array {

--- a/src/Utility/SerializerInterface.php
+++ b/src/Utility/SerializerInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Utility;
 

--- a/src/Utility/SerializerInterface.php
+++ b/src/Utility/SerializerInterface.php
@@ -10,6 +10,7 @@ interface SerializerInterface {
 	 *
 	 * @param array<string, mixed> $data
 	 * @param array<string, mixed> $options Options normalizers/encoders have access to
+	 *
 	 * @return string
 	 */
 	public function serialize(array $data, array $options = []): string;
@@ -19,6 +20,7 @@ interface SerializerInterface {
 	 *
 	 * @param string $data
 	 * @param array<string, mixed> $options
+	 *
 	 * @return array<string, mixed>
 	 */
 	public function deserialize(string $data, array $options = []): array;

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\View\Helper;
 
@@ -15,11 +16,10 @@ class QueueHelper extends Helper {
 	/**
 	 * @var array<string, array<string, mixed>>
 	 */
-	protected $taskConfig;
+	protected array $taskConfig = [];
 
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return bool
 	 */
 	public function hasFailed(QueuedJob $queuedJob): bool {
@@ -43,7 +43,6 @@ class QueueHelper extends Helper {
 
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
 	 * @return string|null
 	 */
 	public function attempts(QueuedJob $queuedJob): ?string {
@@ -86,7 +85,6 @@ class QueueHelper extends Helper {
 
 	/**
 	 * @param string $jobTask
-	 *
 	 * @return array<string, mixed>
 	 */
 	protected function taskConfig(string $jobTask): array {

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -20,6 +20,7 @@ class QueueHelper extends Helper {
 
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return bool
 	 */
 	public function hasFailed(QueuedJob $queuedJob): bool {
@@ -43,6 +44,7 @@ class QueueHelper extends Helper {
 
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return string|null
 	 */
 	public function attempts(QueuedJob $queuedJob): ?string {
@@ -64,6 +66,7 @@ class QueueHelper extends Helper {
 	 * Returns failure status (message) if applicable.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return string|null
 	 */
 	public function failureStatus(QueuedJob $queuedJob): ?string {
@@ -85,6 +88,7 @@ class QueueHelper extends Helper {
 
 	/**
 	 * @param string $jobTask
+	 *
 	 * @return array<string, mixed>
 	 */
 	protected function taskConfig(string $jobTask): array {

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -35,6 +35,7 @@ class QueueProgressHelper extends Helper {
 	 * Returns percentage as formatted value.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return string|null
 	 */
 	public function progress(QueuedJob $queuedJob): ?string {
@@ -60,6 +61,7 @@ class QueueProgressHelper extends Helper {
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param int $length
+	 *
 	 * @return string|null
 	 */
 	public function progressBar(QueuedJob $queuedJob, int $length): ?string {
@@ -81,6 +83,7 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param string|null $fallbackHtml
+	 *
 	 * @return string|null
 	 */
 	public function htmlProgressBar(QueuedJob $queuedJob, ?string $fallbackHtml = null): ?string {
@@ -107,6 +110,7 @@ class QueueProgressHelper extends Helper {
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param int $length
+	 *
 	 * @return string|null
 	 */
 	public function timeoutProgressBar(QueuedJob $queuedJob, int $length): ?string {
@@ -121,6 +125,7 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param string|null $fallbackHtml
+	 *
 	 * @return string|null
 	 */
 	public function htmlTimeoutProgressBar(QueuedJob $queuedJob, ?string $fallbackHtml = null): ?string {
@@ -139,6 +144,7 @@ class QueueProgressHelper extends Helper {
 	 * Calculates the timeout progress rate.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
+	 *
 	 * @return float|null
 	 */
 	protected function calculateTimeoutProgress(QueuedJob $queuedJob): ?float {
@@ -169,6 +175,7 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @param string $jobType
 	 * @param \Cake\I18n\DateTime $fetched
+	 *
 	 * @return float|null
 	 */
 	protected function calculateJobProgress(string $jobType, DateTime $fetched): ?float {
@@ -190,6 +197,7 @@ class QueueProgressHelper extends Helper {
 
 	/**
 	 * @param string $jobType
+	 *
 	 * @return array<int>
 	 */
 	protected function getJobStatistics(string $jobType): array {

--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\View\Helper;
 
@@ -28,7 +29,7 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @var array<string, array<int>>|null
 	 */
-	protected $statistics;
+	protected ?array $statistics = null;
 
 	/**
 	 * Returns percentage as formatted value.
@@ -80,7 +81,6 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param string|null $fallbackHtml
-	 *
 	 * @return string|null
 	 */
 	public function htmlProgressBar(QueuedJob $queuedJob, ?string $fallbackHtml = null): ?string {
@@ -121,7 +121,6 @@ class QueueProgressHelper extends Helper {
 	/**
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @param string|null $fallbackHtml
-	 *
 	 * @return string|null
 	 */
 	public function htmlTimeoutProgressBar(QueuedJob $queuedJob, ?string $fallbackHtml = null): ?string {
@@ -142,7 +141,7 @@ class QueueProgressHelper extends Helper {
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
 	 * @return float|null
 	 */
-	protected function calculateTimeoutProgress(QueuedJob $queuedJob) {
+	protected function calculateTimeoutProgress(QueuedJob $queuedJob): ?float {
 		if ($queuedJob->completed || $queuedJob->fetched || !$queuedJob->notbefore) {
 			return null;
 		}
@@ -172,7 +171,7 @@ class QueueProgressHelper extends Helper {
 	 * @param \Cake\I18n\DateTime $fetched
 	 * @return float|null
 	 */
-	protected function calculateJobProgress(string $jobType, $fetched) {
+	protected function calculateJobProgress(string $jobType, DateTime $fetched): ?float {
 		$stats = $this->getJobStatistics($jobType);
 		if (!$stats) {
 			return null;

--- a/tests/TestCase/Command/AddCommandTest.php
+++ b/tests/TestCase/Command/AddCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/BakeQueueTaskCommandTest.php
+++ b/tests/TestCase/Command/BakeQueueTaskCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/InfoCommandTest.php
+++ b/tests/TestCase/Command/InfoCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/JobCommandTest.php
+++ b/tests/TestCase/Command/JobCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/JobCommandTest.php
+++ b/tests/TestCase/Command/JobCommandTest.php
@@ -132,6 +132,7 @@ class JobCommandTest extends TestCase {
 
 	/**
 	 * @param array $data
+	 *
 	 * @return \Queue\Model\Entity\QueuedJob
 	 */
 	protected function createJob(array $data = []): QueuedJob {

--- a/tests/TestCase/Command/MigrateTasksCommandTest.php
+++ b/tests/TestCase/Command/MigrateTasksCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Command;
 

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Controller\Admin;
 

--- a/tests/TestCase/Controller/Admin/QueueProcessesControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueProcessesControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Controller\Admin;
 

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Controller\Admin;
 
@@ -202,7 +203,6 @@ class QueuedJobsControllerTest extends TestCase {
 
 	/**
 	 * @param array $data
-	 *
 	 * @return \Queue\Model\Entity\QueuedJob
 	 */
 	protected function createJob(array $data = []) {

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -203,6 +203,7 @@ class QueuedJobsControllerTest extends TestCase {
 
 	/**
 	 * @param array $data
+	 *
 	 * @return \Queue\Model\Entity\QueuedJob
 	 */
 	protected function createJob(array $data = []) {

--- a/tests/TestCase/Generator/Task/QueuedJobGeneratorTest.php
+++ b/tests/TestCase/Generator/Task/QueuedJobGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Generator\Task;
 

--- a/tests/TestCase/Mailer/Transport/QueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/QueueTransportTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Mailer\Transport;
 

--- a/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SimpleQueueTransportTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Mailer\Transport;
 
@@ -61,12 +62,12 @@ class SimpleQueueTransportTest extends TestCase {
 
 		$mailer->render('Foo Bar Content');
 		/*
-		$mailer->viewBuilder()->setLayout('test_layout');
-		$mailer->viewBuilder()->setTemplate('test_template');
-		$mailer->viewBuilder()->setTheme('EuroTheme');
-		$mailer->set('var1', 1);
-		$mailer->set('var2', 2);
-		*/
+        $mailer->viewBuilder()->setLayout('test_layout');
+        $mailer->viewBuilder()->setTemplate('test_template');
+        $mailer->viewBuilder()->setTheme('EuroTheme');
+        $mailer->set('var1', 1);
+        $mailer->set('var2', 2);
+        */
 		$mailer->setSubject("L'utilisateur n'a pas pu être enregistré");
 		$mailer->setReplyTo('noreply@cakephp.org');
 		$mailer->setReadReceipt('noreply2@cakephp.org');

--- a/tests/TestCase/Model/Table/QueueProcessesTableTest.php
+++ b/tests/TestCase/Model/Table/QueueProcessesTableTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Model\Table;
 
@@ -131,7 +132,7 @@ class QueueProcessesTableTest extends TestCase {
 		$queuedProcessesTable->saveOrFail($queuedProcess);
 
 		$gotSignal = false;
-		pcntl_signal(SIGUSR1, function() use (&$gotSignal) {
+		pcntl_signal(SIGUSR1, function () use (&$gotSignal) {
 			$gotSignal = true;
 		});
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * @author MGriesbach@gmail.com
  * @license http://www.opensource.org/licenses/mit-license.php The MIT License

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue;
 

--- a/tests/TestCase/Queue/Task/CostsExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/CostsExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/ExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/ExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/ExceptionExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/ExceptionExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/ExecuteTaskTest.php
+++ b/tests/TestCase/Queue/Task/ExecuteTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/MailerTaskTest.php
+++ b/tests/TestCase/Queue/Task/MailerTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/MonitorExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/MonitorExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/ProgressExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/ProgressExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/RetryExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/RetryExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/SuperExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/SuperExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/Task/UniqueExampleTaskTest.php
+++ b/tests/TestCase/Queue/Task/UniqueExampleTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue\Task;
 

--- a/tests/TestCase/Queue/TaskFinderTest.php
+++ b/tests/TestCase/Queue/TaskFinderTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue;
 

--- a/tests/TestCase/Queue/TaskTest.php
+++ b/tests/TestCase/Queue/TaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Queue;
 

--- a/tests/TestCase/Shell/QueueShellTest.php
+++ b/tests/TestCase/Shell/QueueShellTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Shell;
 

--- a/tests/TestCase/Utility/JsonSerializerTest.php
+++ b/tests/TestCase/Utility/JsonSerializerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Utility;
 

--- a/tests/TestCase/Utility/ObjectSerializerTest.php
+++ b/tests/TestCase/Utility/ObjectSerializerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\Utility;
 

--- a/tests/TestCase/View/Helper/QueueHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\View\Helper;
 

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Queue\Test\TestCase\View\Helper;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Cake\Utility\Inflector;
 
@@ -20,7 +21,6 @@ foreach ($iterator as $file) {
 		$fieldsObject = (new ReflectionClass($class))->getProperty('fields');
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
-
 	} catch (ReflectionException $e) {
 		continue;
 	}

--- a/tests/test_app/plugins/Foo/src/Plugin.php
+++ b/tests/test_app/plugins/Foo/src/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo;
 

--- a/tests/test_app/plugins/Foo/src/Queue/Task/FooTask.php
+++ b/tests/test_app/plugins/Foo/src/Queue/Task/FooTask.php
@@ -24,6 +24,7 @@ class FooTask extends Task {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/tests/test_app/plugins/Foo/src/Queue/Task/FooTask.php
+++ b/tests/test_app/plugins/Foo/src/Queue/Task/FooTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Queue\Task;
 
@@ -8,17 +9,13 @@ class FooTask extends Task {
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
-	 *
-	 * @var int
 	 */
-	public $retries = 1;
+	public ?int $retries = 1;
 
 	/**
 	 * Example run function.

--- a/tests/test_app/plugins/Foo/src/Queue/Task/Sub/SubFooTask.php
+++ b/tests/test_app/plugins/Foo/src/Queue/Task/Sub/SubFooTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Queue\Task\Sub;
 
@@ -8,17 +9,13 @@ class SubFooTask extends Task {
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
-	 *
-	 * @var int
 	 */
-	public $retries = 1;
+	public ?int $retries = 1;
 
 	/**
 	 * Example run function.

--- a/tests/test_app/plugins/Foo/src/Queue/Task/Sub/SubFooTask.php
+++ b/tests/test_app/plugins/Foo/src/Queue/Task/Sub/SubFooTask.php
@@ -24,6 +24,7 @@ class SubFooTask extends Task {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp;
 
@@ -34,7 +35,7 @@ class Application extends BaseApplication {
 	 * @param \Cake\Core\ContainerInterface $container
 	 * @return void
 	 */
-	public function	services(ContainerInterface $container): void {
+	public function services(ContainerInterface $container): void {
 		$container->add(TestService::class);
 	}
 

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -13,6 +13,7 @@ class Application extends BaseApplication {
 
 	/**
 	 * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to set in your App Class
+	 *
 	 * @return \Cake\Http\MiddlewareQueue
 	 */
 	public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue {
@@ -33,6 +34,7 @@ class Application extends BaseApplication {
 
 	/**
 	 * @param \Cake\Core\ContainerInterface $container
+	 *
 	 * @return void
 	 */
 	public function services(ContainerInterface $container): void {

--- a/tests/test_app/src/Controller/AppController.php
+++ b/tests/test_app/src/Controller/AppController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Controller;
 

--- a/tests/test_app/src/Mailer/TestMailer.php
+++ b/tests/test_app/src/Mailer/TestMailer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Mailer;
 

--- a/tests/test_app/src/Mailer/TestMailer.php
+++ b/tests/test_app/src/Mailer/TestMailer.php
@@ -9,6 +9,7 @@ class TestMailer extends Mailer {
 
 	/**
 	 * @param bool $isTest
+	 *
 	 * @return $this
 	 */
 	public function testAction(bool $isTest) {

--- a/tests/test_app/src/Model/Table/CategoriesTable.php
+++ b/tests/test_app/src/Model/Table/CategoriesTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Model\Table;
 

--- a/tests/test_app/src/Model/Table/QueuedJobsTable.php
+++ b/tests/test_app/src/Model/Table/QueuedJobsTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Model\Table;
 

--- a/tests/test_app/src/Queue/Task/FooTask.php
+++ b/tests/test_app/src/Queue/Task/FooTask.php
@@ -31,6 +31,7 @@ class FooTask extends Task implements AddInterface {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/tests/test_app/src/Queue/Task/FooTask.php
+++ b/tests/test_app/src/Queue/Task/FooTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Queue\Task;
 
@@ -14,16 +15,14 @@ class FooTask extends Task implements AddInterface {
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
-	 *
-	 * @var int
 	 */
-	public $retries = 1;
+	public ?int $retries = 1;
 
 	/**
 	 * Example run function.

--- a/tests/test_app/src/Queue/Task/Sub/SubFooTask.php
+++ b/tests/test_app/src/Queue/Task/Sub/SubFooTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Queue\Task\Sub;
 
@@ -8,17 +9,13 @@ class SubFooTask extends Task {
 
 	/**
 	 * Timeout for run, after which the Task is reassigned to a new worker.
-	 *
-	 * @var int
 	 */
-	public $timeout = 10;
+	public ?int $timeout = 10;
 
 	/**
 	 * Number of times a failed instance of this task should be restarted before giving up.
-	 *
-	 * @var int
 	 */
-	public $retries = 1;
+	public ?int $retries = 1;
 
 	/**
 	 * Example run function.

--- a/tests/test_app/src/Queue/Task/Sub/SubFooTask.php
+++ b/tests/test_app/src/Queue/Task/Sub/SubFooTask.php
@@ -24,6 +24,7 @@ class SubFooTask extends Task {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/tests/test_app/src/Services/TestService.php
+++ b/tests/test_app/src/Services/TestService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Services;
 

--- a/tests/test_app/src/Shell/Task/QueueFooTask.php
+++ b/tests/test_app/src/Shell/Task/QueueFooTask.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Shell\Task;
 

--- a/tests/test_app/src/Shell/Task/QueueFooTask.php
+++ b/tests/test_app/src/Shell/Task/QueueFooTask.php
@@ -31,6 +31,7 @@ class QueueFooTask extends QueueTask {
 	 *
 	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
 	 * @param int $jobId The id of the QueuedJob entity
+	 *
 	 * @return void
 	 */
 	public function run(array $data, int $jobId): void {

--- a/tests/test_app/src/View/AppView.php
+++ b/tests/test_app/src/View/AppView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\View;
 

--- a/tests/test_files/bake/Sub/task_test.php
+++ b/tests/test_files/bake/Sub/task_test.php
@@ -10,7 +10,7 @@ class FooBarBazTaskTest extends TestCase {
 	/**
 	 * @var array<string>
 	 */
-	protected $fixtures = [
+	protected array $fixtures = [
 		'plugin.Queue.QueuedJobs',
 		'plugin.Queue.QueueProcesses',
 	];

--- a/tests/test_files/bake/task_test.php
+++ b/tests/test_files/bake/task_test.php
@@ -10,7 +10,7 @@ class FooBarBazTaskTest extends TestCase {
 	/**
 	 * @var array<string>
 	 */
-	protected $fixtures = [
+	protected array $fixtures = [
 		'plugin.Queue.QueuedJobs',
 		'plugin.Queue.QueueProcesses',
 	];

--- a/tests/test_files/migrate/FooPluginTask.php
+++ b/tests/test_files/migrate/FooPluginTask.php
@@ -1,22 +1,21 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Bar\Queue\Task;
 
 use Queue\Queue\Task;
 
 class FooPluginTask extends Task {
-
-	/**
-	 * Example run function.
-	 * This function is executed, when a worker is executing a task.
-	 * The return parameter will determine, if the task will be marked completed, or be requeued.
-	 *
-	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
-	 * @param int $jobId The id of the QueuedJob entity
-	 * @return void
-	 */
-	public function run(array $data, int $jobId): void {
-		$this->io->out('CakePHP Foo plugin Example.');
-	}
-
+    /**
+     * Example run function.
+     * This function is executed, when a worker is executing a task.
+     * The return parameter will determine, if the task will be marked completed, or be requeued.
+     *
+     * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
+     * @param int $jobId The id of the QueuedJob entity
+     * @return void
+     */
+    public function run(array $data, int $jobId): void {
+        $this->io->out('CakePHP Foo plugin Example.');
+    }
 }

--- a/tests/test_files/migrate/FooTask.php
+++ b/tests/test_files/migrate/FooTask.php
@@ -1,22 +1,21 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Queue\Task;
 
 use Queue\Queue\Task;
 
 class FooTask extends Task {
-
-	/**
-	 * Example run function.
-	 * This function is executed, when a worker is executing a task.
-	 * The return parameter will determine, if the task will be marked completed, or be requeued.
-	 *
-	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
-	 * @param int $jobId The id of the QueuedJob entity
-	 * @return void
-	 */
-	public function run(array $data, int $jobId): void {
-		$this->io->out('CakePHP Foo Example.');
-	}
-
+    /**
+     * Example run function.
+     * This function is executed, when a worker is executing a task.
+     * The return parameter will determine, if the task will be marked completed, or be requeued.
+     *
+     * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
+     * @param int $jobId The id of the QueuedJob entity
+     * @return void
+     */
+    public function run(array $data, int $jobId): void {
+        $this->io->out('CakePHP Foo Example.');
+    }
 }

--- a/tests/test_files/migrate/QueueFooPluginTask.php
+++ b/tests/test_files/migrate/QueueFooPluginTask.php
@@ -1,22 +1,21 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Bar\Shell\Task;
 
 use Queue\Shell\Task\QueueTask;
 
 class QueueFooPluginTask extends QueueTask {
-
-	/**
-	 * Example run function.
-	 * This function is executed, when a worker is executing a task.
-	 * The return parameter will determine, if the task will be marked completed, or be requeued.
-	 *
-	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
-	 * @param int $jobId The id of the QueuedJob entity
-	 * @return void
-	 */
-	public function run(array $data, int $jobId): void {
-		$this->out('CakePHP Foo plugin Example.');
-	}
-
+    /**
+     * Example run function.
+     * This function is executed, when a worker is executing a task.
+     * The return parameter will determine, if the task will be marked completed, or be requeued.
+     *
+     * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
+     * @param int $jobId The id of the QueuedJob entity
+     * @return void
+     */
+    public function run(array $data, int $jobId): void {
+        $this->out('CakePHP Foo plugin Example.');
+    }
 }

--- a/tests/test_files/migrate/QueueFooTask.php
+++ b/tests/test_files/migrate/QueueFooTask.php
@@ -1,22 +1,21 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Shell\Task;
 
 use Queue\Shell\Task\QueueTask;
 
 class QueueFooTask extends QueueTask {
-
-	/**
-	 * Example run function.
-	 * This function is executed, when a worker is executing a task.
-	 * The return parameter will determine, if the task will be marked completed, or be requeued.
-	 *
-	 * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
-	 * @param int $jobId The id of the QueuedJob entity
-	 * @return void
-	 */
-	public function run(array $data, int $jobId): void {
-		$this->out('CakePHP Foo Example.');
-	}
-
+    /**
+     * Example run function.
+     * This function is executed, when a worker is executing a task.
+     * The return parameter will determine, if the task will be marked completed, or be requeued.
+     *
+     * @param array<string, mixed> $data The array passed to QueuedJobsTable::createJob()
+     * @param int $jobId The id of the QueuedJob entity
+     * @return void
+     */
+    public function run(array $data, int $jobId): void {
+        $this->out('CakePHP Foo Example.');
+    }
 }

--- a/tests/test_files/migrate/test/FooPluginTaskTest.php
+++ b/tests/test_files/migrate/test/FooPluginTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Bar\Test\TestCase\Queue\Task;
 
@@ -8,16 +9,14 @@ use Foo\Bar\Queue\Task\FooPluginTask;
 use Shim\TestSuite\ConsoleOutput;
 
 class FooPluginTaskTest extends TestCase {
+    /**
+     * @return void
+     */
+    public function testRun(): void {
+        $this->out = new ConsoleOutput();
+        $this->err = new ConsoleOutput();
+        $io = new \Queue\Console\Io(new ConsoleIo($this->out, $this->err));
 
-	/**
-	 * @return void
-	 */
-	public function testRun(): void {
-		$this->out = new ConsoleOutput();
-		$this->err = new ConsoleOutput();
-		$io = new \Queue\Console\Io(new ConsoleIo($this->out, $this->err));
-
-		$task = new FooPluginTask($io);
-	}
-
+        $task = new FooPluginTask($io);
+    }
 }

--- a/tests/test_files/migrate/test/FooTaskTest.php
+++ b/tests/test_files/migrate/test/FooTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Test\TestCase\Queue\Task;
 
@@ -8,16 +9,14 @@ use Shim\TestSuite\ConsoleOutput;
 use TestApp\Queue\Task\FooTask;
 
 class FooTaskTest extends TestCase {
+    /**
+     * @return void
+     */
+    public function testRun(): void {
+        $this->out = new ConsoleOutput();
+        $this->err = new ConsoleOutput();
+        $io = new \Queue\Console\Io(new ConsoleIo($this->out, $this->err));
 
-	/**
-	 * @return void
-	 */
-	public function testRun(): void {
-		$this->out = new ConsoleOutput();
-		$this->err = new ConsoleOutput();
-		$io = new \Queue\Console\Io(new ConsoleIo($this->out, $this->err));
-
-		$task = new FooTask($io);
-	}
-
+        $task = new FooTask($io);
+    }
 }

--- a/tests/test_files/migrate/test/QueueFooPluginTaskTest.php
+++ b/tests/test_files/migrate/test/QueueFooPluginTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Foo\Bar\Test\TestCase\Shell\Task;
 
@@ -8,16 +9,14 @@ use Foo\Bar\Shell\Task\QueueFooPluginTask;
 use Shim\TestSuite\ConsoleOutput;
 
 class QueueFooPluginTaskTest extends TestCase {
+    /**
+     * @return void
+     */
+    public function testRun(): void {
+        $this->out = new ConsoleOutput();
+        $this->err = new ConsoleOutput();
+        $io = new ConsoleIo($this->out, $this->err);
 
-	/**
-	 * @return void
-	 */
-	public function testRun(): void {
-		$this->out = new ConsoleOutput();
-		$this->err = new ConsoleOutput();
-		$io = new ConsoleIo($this->out, $this->err);
-
-		$task = new QueueFooPluginTask($io);
-	}
-
+        $task = new QueueFooPluginTask($io);
+    }
 }

--- a/tests/test_files/migrate/test/QueueFooTaskTest.php
+++ b/tests/test_files/migrate/test/QueueFooTaskTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace TestApp\Test\TestCase\Shell\Task;
 
@@ -8,16 +9,14 @@ use Shim\TestSuite\ConsoleOutput;
 use TestApp\Shell\Task\QueueFooTask;
 
 class QueueFooTaskTest extends TestCase {
+    /**
+     * @return void
+     */
+    public function testRun(): void {
+        $this->out = new ConsoleOutput();
+        $this->err = new ConsoleOutput();
+        $io = new ConsoleIo($this->out, $this->err);
 
-	/**
-	 * @return void
-	 */
-	public function testRun(): void {
-		$this->out = new ConsoleOutput();
-		$this->err = new ConsoleOutput();
-		$io = new ConsoleIo($this->out, $this->err);
-
-		$task = new QueueFooTask($io);
-	}
-
+        $task = new QueueFooTask($io);
+    }
 }


### PR DESCRIPTION
The current `5.x` version of https://github.com/cakephp/cakephp-codesniffer/tree/5.x requires all properties to have a php native typehint added (if possible). So it automatically fails for e.g.
```
class UpdatePluginTask extends Task
{
    public $timeout = 900;
}
```

because 
```
 18 | ERROR | Property \App\Queue\Task\UpdatePluginTask::$timeout
    |       | does not have native type hint nor @var annotation for
    |       | its value.
    |       | (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint)
```

now I could have manually added all those typehints to this plugin but this would have been very tedious.

Therefore I 
* temporarily installed the `cakephp-codesniffer` 5.x version
* let it automatically fix all problems it could detect
* removed it again
* let your cs-fixer rules fix whatever is left

and here we are with a bunch of `declare(strict_types=1);` added, cleaned up property types, return types and phpdocs.

So it seems your cs rules are not as "strict" as CakePHP's are.

I personally would prefer if this plugin would also just go with the rules of `cakephp/cakephp-codesniffer` but this is of course not my decision to make.