### PR TITLE
add status field queued_jobs to search

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -145,7 +145,7 @@ class QueuedJobsTable extends Table {
 		$searchManager = $this->behaviors()->Search->searchManager();
 		$searchManager
 			->value('job_task')
-			->like('search', ['fields' => ['job_group', 'reference'], 'before' => true, 'after' => true])
+			->like('search', ['fields' => ['job_group', 'reference', 'status'], 'before' => true, 'after' => true])
 			->add('status', 'Search.Callback', [
 				'callback' => function (SelectQuery $query, array $args, $filter) {
 					$status = $args['status'];


### PR DESCRIPTION
I like to add additional info into the `status` field of a done job

![image](https://github.com/dereuromark/cakephp-queue/assets/9105243/ac1e485a-c2a3-471b-b5b5-4c043f41a6c9)

So it would be cool if the plugin adds this field to the default text search, not only the job_group and reference.