### PR TITLE
Improve usage of defaultworkertimeout

### DIFF
--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -199,8 +199,12 @@ class QueueProcessesTable extends Table {
 	 */
 	public function cleanEndedProcesses(): int {
 		$activeProcesses = $this->findActive()->all()->extract('id')->toArray();
+		$conditions = [];
+		if (count($activeProcesses) > 0) {
+			$conditions = ['id NOT IN' => $activeProcesses];
+		}
 
-		return $this->deleteAll(['id NOT IN' => $activeProcesses]);
+		return $this->deleteAll($conditions);
 	}
 
 	/**

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -198,13 +198,10 @@ class QueueProcessesTable extends Table {
 	 * @return int
 	 */
 	public function cleanEndedProcesses(): int {
-		$activeProcesses = $this->findActive()->all()->extract('id')->toArray();
-		$conditions = [];
-		if (count($activeProcesses) > 0) {
-			$conditions = ['id NOT IN' => $activeProcesses];
-		}
+		$timeout = Config::defaultworkertimeout();
+		$thresholdTime = (new DateTime())->subSeconds($timeout);
 
-		return $this->deleteAll($conditions);
+		return $this->deleteAll(['modified <' => $thresholdTime]);
 	}
 
 	/**

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -198,10 +198,9 @@ class QueueProcessesTable extends Table {
 	 * @return int
 	 */
 	public function cleanEndedProcesses(): int {
-		$timeout = Config::defaultworkertimeout();
-		$thresholdTime = (new DateTime())->subSeconds($timeout);
+		$activeProcesses = $this->findActive();
 
-		return $this->deleteAll(['modified <' => $thresholdTime]);
+		return $this->deleteAll(['id NOT IN' => $activeProcesses->select(['id'])]);
 	}
 
 	/**

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -198,9 +198,9 @@ class QueueProcessesTable extends Table {
 	 * @return int
 	 */
 	public function cleanEndedProcesses(): int {
-		$activeProcesses = $this->findActive();
+		$activeProcesses = $this->findActive()->all()->extract('id')->toArray();
 
-		return $this->deleteAll(['id NOT IN' => $activeProcesses->select(['id'])]);
+		return $this->deleteAll(['id NOT IN' => $activeProcesses]);
 	}
 
 	/**

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -535,7 +535,7 @@ class QueuedJobsTable extends Table {
 			$constraintJobs = array_keys($costConstraints + $uniqueConstraints);
 			$runningJobs = $this->find('queued')
 				->contain(['WorkerProcesses'])
-				->where(['QueuedJobs.job_task IN' => $constraintJobs, 'QueuedJobs.workerkey IS NOT' => null, 'QueuedJobs.workerkey !=' => $this->_key, 'WorkerProcesses.modified >' => Config::defaultworkertimeout()])
+				->where(['QueuedJobs.job_task IN' => $constraintJobs, 'QueuedJobs.workerkey IS NOT' => null, 'QueuedJobs.workerkey !=' => $this->_key, 'WorkerProcesses.modified >' => (new DateTime())->subSeconds(Config::defaultworkertimeout())])
 				->all()
 				->toArray();
 		}

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -11,12 +11,16 @@ class Config {
 	/**
 	 * Timeout in seconds, after which the Task is reassigned to a new worker
 	 * if not finished successfully.
-	 * This should be high enough that it cannot still be running on a zombie worker (>> 2x).
+	 * This should be high enough that it cannot still be running on a zombie worker (>> 2x) and cannot be zero.
 	 *
 	 * @return int
 	 */
 	public static function defaultworkertimeout(): int {
-		return Configure::read('Queue.defaultworkertimeout', 600); // 10min
+		$timeout = Configure::read('Queue.defaultworkertimeout', 600); // 10min
+		if ($timeout<=0) {
+			throw new InvalidArgumentException('Queue.defaultworkertimeout is less or eqaul than zero. Indefinite running of workers is not supported.');
+		}
+		return $timeout;
 	}
 
 	/**

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -18,7 +18,7 @@ class Config {
 	public static function defaultworkertimeout(): int {
 		$timeout = Configure::read('Queue.defaultworkertimeout', 600); // 10min
 		if ($timeout <= 0) {
-			throw new InvalidArgumentException('Queue.defaultworkertimeout is less or eqaul than zero. Indefinite running of workers is not supported.');
+			throw new InvalidArgumentException('Queue.defaultworkertimeout is less or equal than zero. Indefinite running of workers is not supported.');
 		}
 
 		return $timeout;

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -17,9 +17,10 @@ class Config {
 	 */
 	public static function defaultworkertimeout(): int {
 		$timeout = Configure::read('Queue.defaultworkertimeout', 600); // 10min
-		if ($timeout<=0) {
+		if ($timeout <= 0) {
 			throw new InvalidArgumentException('Queue.defaultworkertimeout is less or eqaul than zero. Indefinite running of workers is not supported.');
 		}
+
 		return $timeout;
 	}
 


### PR DESCRIPTION
See #400 for explanation. 

- Fixes error in not using a relative DateTime for finding running jobs which are out of time
- Throw exception for usage of defaultworkertimeout of 0 seconds as it is clearly not supported.