### PR TITLE
Support DTO like input.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"cakephp/migrations": "^4.0.1",
 		"dereuromark/cakephp-ide-helper": "^2.0.0",
 		"dereuromark/cakephp-tools": "^3.0.0",
+		"dereuromark/cakephp-dto": "^2.1.0",
 		"fig-r/psr2r-sniffer": "dev-next",
 		"friendsofcake/search": "^7.0.0",
 		"phpunit/phpunit": "^10.1"

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -237,7 +237,7 @@ class QueuedJobsTable extends Table {
 			$data = $data->toArray();
 		}
 		if ($data !== null && !is_array($data)) {
-			throw new InvalidArgumentException('Data must be an array or implement `' . FromArrayToArrayInterface::class . '`');
+			throw new InvalidArgumentException('Data must be `array|null`, implement `' . FromArrayToArrayInterface::class . '` or provide a `toArray()` method');
 		}
 
 		$queuedJob = [

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -16,6 +16,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Queue\Model\Table\QueuedJobsTable;
 use Queue\Queue\Task\ExampleTask;
+use TestApp\Dto\MyTaskDto;
 
 /**
  * Queue\Model\Table\QueuedJobsTable Test Case
@@ -221,6 +222,46 @@ class QueuedJobsTableTest extends TestCase {
 			'test' => 'data',
 		]);
 		$this->assertTrue((bool)$queuedJob);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCreateWithDto() {
+		$array = [
+			'some' => 'random',
+			'test' => 'data',
+		];
+		$dto = new MyTaskDto($array);
+
+		$queuedJob = $this->QueuedJobs->createJob(ExampleTask::class, $dto);
+		$this->assertTrue((bool)$queuedJob);
+		$this->assertSame($array, $queuedJob->data);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCreateWithObject() {
+		$array = [
+			'some' => 'random',
+			'test' => 'data',
+		];
+		$dto = new class() {
+			/**
+			 * @return string[]
+			 */
+			public function toArray(): array {
+				return [
+					'some' => 'random',
+					'test' => 'data',
+				];
+			}
+		};
+
+		$queuedJob = $this->QueuedJobs->createJob(ExampleTask::class, $dto);
+		$this->assertTrue((bool)$queuedJob);
+		$this->assertSame($array, $queuedJob->data);
 	}
 
 	/**

--- a/tests/test_app/src/Dto/MyTaskDto.php
+++ b/tests/test_app/src/Dto/MyTaskDto.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Dto;
+
+use CakeDto\Dto\FromArrayToArrayInterface;
+
+class MyTaskDto implements FromArrayToArrayInterface {
+
+	protected array $data;
+
+	/**
+	 * @param array $data
+	 */
+	public function __construct(array $data) {
+		$this->data = $data;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFoo(): string {
+		return 'foo';
+	}
+
+	/**
+	 * @param array $array
+	 *
+	 * @return static
+	 */
+	public static function createFromArray(array $array): static {
+		return new static($array);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array {
+		return $this->data;
+	}
+
+}


### PR DESCRIPTION
As discussed in https://github.com/dereuromark/cakephp-queue/issues/410 this is all we can do for now it seems.
It is optional, so everything works also as before

The idea is to have a bit more native DTO support built in
Now you can do

`bin/cake dto generate` for
```xml
    <dto name="EventUpdateNotificationQueueData" immutable="true">
        <field name="eventId" type="int" required="true"/>
        <field name="mailer" type="string" required="true"/>
        <field name="type" type="string" required="true"/>
    </dto>
```    
and
```php
$dataDto = OrderUpdateNotificationQueueDataDto::createFromArray([
    OrderUpdateNotificationQueueDataDto::FIELD_ORDER_ID => $order->id,
    OrderUpdateNotificationQueueDataDto::FIELD_MAILER => 'Request',
    OrderUpdateNotificationQueueDataDto::FIELD_TYPE => 'requestToEventsetting',
]);
$this->getTableLocator()->get('Queue.QueuedJobs')->createJob('OrderUpdateNotification', $dataDto);
```
as well as this inside the queue task:
```php
    public function run(array $data, int $jobId): void
    {
        $dataDto = OrderUpdateNotificationQueueDataDto::createFromArray($data);

        $order = $this->fetchTable('Orders')->get($dataDto->getOrderId());
        $this->getMailer($queueData->getMailer())->send($dataDto->getType(), [$order]);
    }
```

with maximum IDE and Stan support as well as immediate errors on missing required fields etc.