### PR TITLE
Update 20231112807150_MigrationAddIndex.php

### DIFF
--- a/config/Migrations/20231112807150_MigrationAddIndex.php
+++ b/config/Migrations/20231112807150_MigrationAddIndex.php
@@ -9,9 +9,9 @@ class MigrationAddIndex extends AbstractMigration {
 	 */
 	public function change() {
 		// Shim: make sure this is void when a migrating with `202311128071500` instead of `20231112807150` has been run already.
-		$result = $this->query('SELECT * FROM `queue_phinxlog` WHERE version = "202311128071500" LIMIT 1')->fetch();
+		$result = $this->query('SELECT * FROM queue_phinxlog WHERE version = \'202311128071500\' LIMIT 1')->fetch();
 		if ($result) {
-			$this->execute('DELETE FROM `queue_phinxlog` WHERE version = "202311128071500" LIMIT 1');
+			$this->execute('DELETE FROM queue_phinxlog WHERE version = \'202311128071500\' LIMIT 1');
 
 			return;
 		}


### PR DESCRIPTION
Changes to make the migration work with Postgresql. 
Backtick in column names not working, and double quotes around values interpreted as a column name.