### PR TITLE
unwrap the adapter before checking its instance

### DIFF
--- a/config/Migrations/20250909132048_ChangeQueuedJobsDataLength.php
+++ b/config/Migrations/20250909132048_ChangeQueuedJobsDataLength.php
@@ -47,7 +47,7 @@ class ChangeQueuedJobsDataLength extends AbstractMigration {
 	/**
 	 * Gets the unwrapped adapter
 	 *
-	 * @return void
+	 * @return \Phinx\Db\Adapter\AdapterInterface|null
 	 */
 	private function getUnwrappedAdapter(): ?AdapterInterface {
 		$adapter = $this->adapter;


### PR DESCRIPTION
I have created ChangeQueuedJobsDataLength migration that is a copy of Utf8mb4Fix, but unwraps the adapter before checking its intance.