### PR TITLE
fixed MysqlAdapter check in Utf8mb4Fix migration

### DIFF
--- a/config/Migrations/20250911102645_DataColumnLength.php
+++ b/config/Migrations/20250911102645_DataColumnLength.php
@@ -1,0 +1,61 @@
+<?php
+
+use Cake\Error\Debugger;
+use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Adapter\AdapterWrapper;
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+class DataColumnLength extends AbstractMigration {
+
+	/**
+	 * Change Method.
+	 *
+	 * Write your reversible migrations using this method.
+	 *
+	 * More information on writing migrations is available here:
+	 * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+	 *
+	 * @return void
+	 */
+	public function change() {
+		if ($this->getUnwrappedAdapter() instanceof MysqlAdapter) {
+			try {
+				$table = $this->table('queued_jobs');
+				$table->changeColumn('data', 'text', [
+					'limit' => MysqlAdapter::TEXT_MEDIUM,
+					'null' => true,
+					'default' => null,
+					'encoding' => 'utf8mb4',
+					'collation' => 'utf8mb4_unicode_ci',
+				]);
+				$table->changeColumn('failure_message', 'text', [
+					'limit' => MysqlAdapter::TEXT_MEDIUM,
+					'null' => true,
+					'default' => null,
+					'encoding' => 'utf8mb4',
+					'collation' => 'utf8mb4_unicode_ci',
+				]);
+				$table->update();
+			} catch (Exception $e) {
+				Debugger::dump($e->getMessage());
+			}
+		}
+	}
+
+	/**
+	 * Gets the unwrapped adapter
+	 *
+	 * @return \Phinx\Db\Adapter\AdapterInterface|null
+	 */
+	private function getUnwrappedAdapter(): ?AdapterInterface {
+		$adapter = $this->adapter;
+
+		while ($adapter instanceof AdapterWrapper) {
+			$adapter = $adapter->getAdapter();
+		}
+
+		return $adapter;
+	}
+
+}


### PR DESCRIPTION
This PR is related to #441.

In MySQL databases, the text columns `data` and `failure_message` should have a length limit of `MEDIUM`, but they do not. This is because the if condition in [Utf8mb4Fix](https://github.com/dereuromark/cakephp-queue/blob/cake4/config/Migrations/20171013133145_Utf8mb4Fix.php#L69)  will never be satisfied, since the `MysqlAdapter` will be wrapped inside the `CakeAdapter`.

This PR fixes the if condition, getting the adapter inside the wrapper before checking it's instance.