### PR TITLE
Fix TypeError when editing queued job with invalid JSON payload

### DIFF
--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -8,6 +8,7 @@ use Cake\Core\Plugin;
 use Cake\Http\Exception\NotFoundException;
 use Cake\I18n\DateTime;
 use Cake\View\JsonView;
+use InvalidArgumentException;
 use Queue\Queue\TaskFinder;
 use RuntimeException;
 
@@ -304,14 +305,21 @@ class QueuedJobsController extends QueueAppController {
 		}
 
 		if ($this->request->is(['patch', 'post', 'put'])) {
-			$queuedJob = $this->QueuedJobs->patchEntity($queuedJob, $this->request->getData());
-			if ($this->QueuedJobs->save($queuedJob)) {
-				$this->Flash->success(__d('queue', 'The queued job has been saved.'));
+			try {
+				$queuedJob = $this->QueuedJobs->patchEntity($queuedJob, $this->request->getData());
+				if ($this->QueuedJobs->save($queuedJob)) {
+					$this->Flash->success(__d('queue', 'The queued job has been saved.'));
 
-				return $this->redirect(['action' => 'view', $id]);
+					return $this->redirect(['action' => 'view', $id]);
+				}
+
+				$this->Flash->error(__d('queue', 'The queued job could not be saved. Please try again.'));
+			} catch (InvalidArgumentException $e) {
+				$this->Flash->error($e->getMessage());
+
+				// Preserve the user's invalid input so they can fix it
+				$queuedJob->data_string = $this->request->getData('data_string');
 			}
-
-			$this->Flash->error(__d('queue', 'The queued job could not be saved. Please try again.'));
 		}
 
 		$this->set(compact('queuedJob'));

--- a/src/Model/Behavior/JsonableBehavior.php
+++ b/src/Model/Behavior/JsonableBehavior.php
@@ -216,10 +216,15 @@ class JsonableBehavior extends Behavior {
 	/**
 	 * @param string $val
 	 *
+	 * @throws \InvalidArgumentException
+	 *
 	 * @return array
 	 */
 	protected function _fromJson(string $val): array {
-		$json = json_decode($val, true, JSON_THROW_ON_ERROR);
+		$json = json_decode($val, true);
+		if (!is_array($json)) {
+			throw new InvalidArgumentException('Invalid JSON: ' . json_last_error_msg());
+		}
 
 		return $json;
 	}

--- a/src/Model/Entity/QueuedJob.php
+++ b/src/Model/Entity/QueuedJob.php
@@ -9,6 +9,7 @@ use Cake\ORM\Entity;
  * @property int $id
  * @property string $job_task
  * @property array|null $data
+ * @property string|null $data_string Virtual property from JsonableBehavior
  * @property string|null $job_group
  * @property string|null $reference
  * @property \Cake\I18n\DateTime $created

--- a/src/Queue/Task/CostsExampleTask.php
+++ b/src/Queue/Task/CostsExampleTask.php
@@ -33,7 +33,7 @@ class CostsExampleTask extends Task implements AddInterface, AddFromBackendInter
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue CostsExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/ExampleTask.php
+++ b/src/Queue/Task/ExampleTask.php
@@ -36,7 +36,7 @@ class ExampleTask extends Task implements AddInterface, AddFromBackendInterface 
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue Example task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/ExceptionExampleTask.php
+++ b/src/Queue/Task/ExceptionExampleTask.php
@@ -32,7 +32,7 @@ class ExceptionExampleTask extends Task implements AddInterface, AddFromBackendI
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue ExceptionExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/MonitorExampleTask.php
+++ b/src/Queue/Task/MonitorExampleTask.php
@@ -38,7 +38,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue MonitorExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/ProgressExampleTask.php
+++ b/src/Queue/Task/ProgressExampleTask.php
@@ -36,7 +36,7 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue ProgressExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add the Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/RetryExampleTask.php
+++ b/src/Queue/Task/RetryExampleTask.php
@@ -68,7 +68,7 @@ class RetryExampleTask extends Task implements AddInterface, AddFromBackendInter
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue RetryExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/SuperExampleTask.php
+++ b/src/Queue/Task/SuperExampleTask.php
@@ -36,7 +36,7 @@ class SuperExampleTask extends Task implements AddInterface, AddFromBackendInter
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue SuperExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/src/Queue/Task/UniqueExampleTask.php
+++ b/src/Queue/Task/UniqueExampleTask.php
@@ -33,7 +33,7 @@ class UniqueExampleTask extends Task implements AddInterface, AddFromBackendInte
 	public function add(?string $data): void {
 		$this->io->out('CakePHP Queue UniqueExample task.');
 		$this->io->hr();
-		$this->io->out($this->description());
+		$this->io->out($this->description() ?? '');
 		$this->io->out('I will now add an example Job into the Queue.');
 		$this->io->out(' ');
 		$this->io->out('To run a Worker use:');

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -134,6 +134,27 @@ JSON,
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testDataPostInvalidJson(): void {
+		$job = $this->createJob(['data' => '{"valid":"json"}']);
+
+		$this->enableRetainFlashMessages();
+		$data = [
+			'data_string' => 'not valid json {',
+		];
+		$this->post(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'data', $job->id], $data);
+
+		$this->assertResponseCode(200);
+		$this->assertFlashMessage('Invalid JSON: Syntax error');
+
+		// Verify original data was not modified
+		/** @var \Queue\Model\Entity\QueuedJob $job */
+		$job = $this->fetchTable('Queue.QueuedJobs')->get($job->id);
+		$this->assertSame('{"valid":"json"}', $job->data);
+	}
+
+	/**
 	 * Test index method
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

- When invalid JSON is submitted via the data edit form (`/admin/queue/queued-jobs/data/{id}`), the JsonableBehavior threw a TypeError because `json_decode` returned `null` but the return type was `array`
- Now shows a proper flash error message (e.g., "Invalid JSON: Syntax error") and preserves the user's invalid input so they can fix it

## Changes

- Update `_fromJson()` in JsonableBehavior to throw `InvalidArgumentException` with a descriptive error message instead of TypeError
- Catch the exception in `data()` action and show a flash error
- Preserve the user's invalid input so they can fix it
- Add test for invalid JSON handling