### PR TITLE
Fix EmailTask named-parameter error for associative address arrays

### DIFF
--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -163,6 +163,17 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 		$this->mailer = $this->getMailer();
 
 		$settings = $data['settings'] + $this->defaults;
+
+		foreach (['to', 'from', 'cc', 'bcc', 'replyTo', 'sender', 'returnPath'] as $addressMethod) {
+			if (!array_key_exists($addressMethod, $settings)) {
+				continue;
+			}
+
+			$setter = 'set' . ucfirst($addressMethod);
+			$this->mailer->{$setter}(...$this->addressArguments($settings[$addressMethod]));
+			unset($settings[$addressMethod]);
+		}
+
 		foreach ($settings as $method => $setting) {
 			$setter = 'set' . ucfirst($method);
 			if (in_array($method, ['theme', 'template', 'layout'], true)) {
@@ -204,6 +215,26 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 		}
 
 		$this->mailer->deliver((string)$message);
+	}
+
+	/**
+	 * Normalizes an address setting into positional arguments for setTo/setFrom/etc.
+	 *
+	 * List-shaped arrays are unpacked into positional arguments (matching the
+	 * historical `call_user_func_array` behavior), while associative `email => name`
+	 * maps are passed as a single positional argument so PHP 8 does not interpret
+	 * their string keys as named parameters.
+	 *
+	 * @param mixed $setting
+     *
+	 * @return array
+	 */
+	protected function addressArguments(mixed $setting): array {
+		if (is_array($setting) && $setting !== [] && array_is_list($setting)) {
+			return $setting;
+		}
+
+		return [$setting];
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -250,7 +250,7 @@ class QueuedJobsTableTest extends TestCase {
 			'some' => 'random',
 			'test' => 'data',
 		];
-		$dto = new class() {
+		$dto = new class () {
 			/**
 			 * @return string[]
 			 */

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -209,6 +209,51 @@ class EmailTaskTest extends TestCase {
 	}
 
 	/**
+	 * Address settings stored as associative `email => name` maps must be
+	 * accepted without triggering PHP 8 "Unknown named parameter" errors.
+	 *
+	 * @return void
+	 */
+	public function testRunArrayAssociativeAddressMap() {
+		$settings = [
+			'from' => [
+				'sender@test.de' => 'Sender Name',
+			],
+			'to' => [
+				'recipient@test.de' => 'Recipient Name',
+			],
+			'cc' => [
+				'copy@test.de' => 'Copy Name',
+				'copy-other@test.de' => 'Other Copy Name',
+			],
+			'bcc' => [
+				'bcc@test.de' => 'BCC Name',
+			],
+			'replyTo' => [
+				'reply@test.de' => 'Reply Name',
+			],
+		];
+
+		$data = [
+			'settings' => $settings,
+			'content' => 'Foo Bar',
+		];
+		$this->Task->run($data, 0);
+
+		$this->assertInstanceOf(Mailer::class, $this->Task->mailer);
+
+		$mailer = $this->Task->mailer;
+		$this->assertSame(['sender@test.de' => 'Sender Name'], $mailer->getFrom());
+		$this->assertSame(['recipient@test.de' => 'Recipient Name'], $mailer->getTo());
+		$this->assertSame([
+			'copy@test.de' => 'Copy Name',
+			'copy-other@test.de' => 'Other Copy Name',
+		], $mailer->getCc());
+		$this->assertSame(['bcc@test.de' => 'BCC Name'], $mailer->getBcc());
+		$this->assertSame(['reply@test.de' => 'Reply Name'], $mailer->getReplyTo());
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testRunToolsEmailMessageClassString() {

--- a/tests/test_app/templates/Error/error500.php
+++ b/tests/test_app/templates/Error/error500.php
@@ -3,31 +3,31 @@
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
-if (Configure::read('debug')) :
+if (Configure::read('debug')) {
 	$this->layout = 'dev_error';
 
 	$this->assign('title', $message);
 	$this->assign('templateName', 'error500.ctp');
 
 	$this->start('file');
-	if (!empty($error->queryString)) : ?>
+	if (!empty($error->queryString)) { ?>
     <p class="notice">
         <strong>SQL Query: </strong>
         <?= h($error->queryString) ?>
     </p>
-	<?php endif; ?>
-	<?php if (!empty($error->params)) : ?>
+	<?php }
+	if (!empty($error->params)) { ?>
         <strong>SQL Query Params: </strong>
         <?= Debugger::dump($error->params) ?>
-	<?php endif;
+	<?php }
 	echo $this->element('auto_table_warning');
 
-	if (extension_loaded('xdebug')) :
+	if (extension_loaded('xdebug')) {
 		xdebug_print_function_stack();
-	endif;
+	}
 
 	$this->end();
-endif;
+}
 ?>
 <h2><?= __d('cake', 'An Internal Error Has Occurred') ?></h2>
 <p class="error">


### PR DESCRIPTION
## Summary

Fixes #471.

`EmailTask::run()` expanded every mailer setting through `call_user_func_array()`. Under PHP 8+, string keys in the argument array are interpreted as named parameters, so queued payloads using CakePHP's associative address-map format:

```php
'to' => ['recipient@example.com' => 'Recipient Name']
```

...failed with `Unknown named parameter $recipient@example.com` against `setTo()`/`setFrom()`/etc.

## Fix

Address setters (`to`, `from`, `cc`, `bcc`, `replyTo`, plus `sender`/`returnPath`) are now handled explicitly before the generic settings loop, consistent with how `theme`/`template`/`attachments` were already special-cased.

A small `addressArguments()` helper normalizes the value:
- list-shaped arrays (e.g. `['email', 'Name']` or legacy wrapped `[['email' => 'Name']]`) are unpacked positionally — matching the previous behavior,
- any other shape, including associative `email => name` maps, is forwarded as a single positional argument so PHP's named-parameter semantics never kick in.

All previously working payload formats continue to work unchanged; the associative map format now also works, matching what `Cake\Mailer\Mailer::setTo()` natively accepts.

A regression test covers `to`, `from`, `cc`, `bcc`, and `replyTo` with associative address maps.