### PR TITLE
Fix EmailTask undefined-method errors for serialized Message settings

### DIFF
--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -186,6 +186,13 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 			unset($settings['textMessage']);
 		}
 
+		// `headers` must be passed as a single positional argument — the map's string
+		// keys would otherwise be interpreted as named parameters under PHP 8.
+		if (array_key_exists('headers', $settings)) {
+			$this->mailer->getMessage()->setHeaders((array)$settings['headers']);
+			unset($settings['headers']);
+		}
+
 		// `appCharset` has no setter on Mailer or Message. Fall back to the Message
 		// charset when a dedicated `charset` value was not also provided.
 		if (array_key_exists('appCharset', $settings)) {

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -164,7 +164,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 
 		$settings = $data['settings'] + $this->defaults;
 
-		foreach (['to', 'from', 'cc', 'bcc', 'replyTo', 'sender', 'returnPath'] as $addressMethod) {
+		foreach (['to', 'from', 'cc', 'bcc', 'replyTo', 'sender', 'returnPath', 'readReceipt'] as $addressMethod) {
 			if (!array_key_exists($addressMethod, $settings)) {
 				continue;
 			}
@@ -172,6 +172,28 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 			$setter = 'set' . ucfirst($addressMethod);
 			$this->mailer->{$setter}(...$this->addressArguments($settings[$addressMethod]));
 			unset($settings[$addressMethod]);
+		}
+
+		// Message body keys from a serialized Message payload use different names than
+		// their setter methods. Route them explicitly so the generic loop does not try
+		// to call nonexistent `setHtmlMessage`/`setTextMessage` on the Mailer.
+		if (array_key_exists('htmlMessage', $settings)) {
+			$this->mailer->getMessage()->setBodyHtml((string)$settings['htmlMessage']);
+			unset($settings['htmlMessage']);
+		}
+		if (array_key_exists('textMessage', $settings)) {
+			$this->mailer->getMessage()->setBodyText((string)$settings['textMessage']);
+			unset($settings['textMessage']);
+		}
+
+		// `appCharset` has no setter on Mailer or Message. Fall back to the Message
+		// charset when a dedicated `charset` value was not also provided.
+		if (array_key_exists('appCharset', $settings)) {
+			$appCharset = (string)$settings['appCharset'];
+			unset($settings['appCharset']);
+			if (!array_key_exists('charset', $settings)) {
+				$this->mailer->getMessage()->setCharset($appCharset);
+			}
 		}
 
 		foreach ($settings as $method => $setting) {

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -254,6 +254,43 @@ class EmailTaskTest extends TestCase {
 	}
 
 	/**
+	 * Settings keys coming from a JSON-round-tripped `Message::__serialize()` payload
+	 * (e.g. `htmlMessage`, `textMessage`, `appCharset`) must not be routed to
+	 * nonexistent `set<Prop>()` methods on the Mailer.
+	 *
+	 * @return void
+	 */
+	public function testRunArrayMessageSerializableProperties() {
+		$settings = [
+			'from' => 'sender@test.de',
+			'to' => 'recipient@test.de',
+			'subject' => 'Message Subject',
+			'domain' => 'example.com',
+			'charset' => 'utf-8',
+			'headerCharset' => 'utf-8',
+			'appCharset' => 'UTF-8',
+			'emailFormat' => 'html',
+			'messageId' => true,
+			'htmlMessage' => '<p>Hello</p>',
+			'textMessage' => 'Hello',
+		];
+
+		$data = [
+			'settings' => $settings,
+		];
+		$this->Task->run($data, 0);
+
+		$this->assertInstanceOf(Mailer::class, $this->Task->mailer);
+
+		$message = $this->Task->mailer->getMessage();
+		$this->assertSame('Message Subject', $message->getSubject());
+		$this->assertSame('example.com', $message->getDomain());
+		$this->assertSame('html', $message->getEmailFormat());
+		$this->assertSame('utf-8', $message->getCharset());
+		$this->assertSame('utf-8', $message->getHeaderCharset());
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testRunToolsEmailMessageClassString() {

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -291,6 +291,35 @@ class EmailTaskTest extends TestCase {
 	}
 
 	/**
+	 * An associative `headers` map inside `settings` must not be expanded into named
+	 * parameters when calling `Message::setHeaders()`.
+	 *
+	 * @return void
+	 */
+	public function testRunArrayHeadersInSettings() {
+		$settings = [
+			'from' => 'sender@test.de',
+			'to' => 'recipient@test.de',
+			'headers' => [
+				'X-Custom' => 'queued',
+				'X-Other' => 'value',
+			],
+		];
+
+		$data = [
+			'settings' => $settings,
+			'content' => 'Foo Bar',
+		];
+		$this->Task->run($data, 0);
+
+		$this->assertInstanceOf(Mailer::class, $this->Task->mailer);
+
+		$headers = $this->Task->mailer->getMessage()->getHeaders(['_headers']);
+		$this->assertSame('queued', $headers['X-Custom']);
+		$this->assertSame('value', $headers['X-Other']);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testRunToolsEmailMessageClassString() {


### PR DESCRIPTION
## Summary

Fixes #473.

Building on #472, this tackles pre-existing bugs in the same code path that were shadowed by the named-parameter crash. Once address settings stopped throwing first, the generic settings loop started calling undefined methods and re-hitting the named-param issue on non-address keys:

```
Error: Call to undefined method Cake\Mailer\Message::setAppCharset()
Error: Unknown named parameter $X-Custom  (headers map)
```

## Fix

Before the generic settings loop, handle the mismatched/unsafe keys explicitly:

| Settings key | Action |
|---|---|
| `htmlMessage` | `Message::setBodyHtml()` |
| `textMessage` | `Message::setBodyText()` |
| `appCharset`  | `Message::setCharset()` when no explicit `charset` is also provided (appCharset has no dedicated setter anywhere) |
| `readReceipt` | added to the address-setter list so associative `email => name` inputs work without PHP 8 named-parameter issues |
| `headers`     | `Message::setHeaders()` called with the map as a single positional argument, so string header names are not interpreted as named parameters |

The generic `call_user_func_array` fallback is kept, so any custom `set*` keys consumers currently rely on continue to work unchanged.

Covered all 20 entries in `Message::$serializableProperties`:
- 8 address-shape keys (to/from/cc/bcc/replyTo/sender/returnPath/readReceipt) — routed through the address path from #472
- 3 keys without matching setters (htmlMessage/textMessage/appCharset) — routed to their real Message methods
- 1 key with an associative-value named-param risk (headers) — routed as a single positional argument
- 8 straightforward scalar keys (subject/emailFormat/emailPattern/domain/messageId/charset/headerCharset/attachments) — continue via the existing generic/special-case paths (verified safe: non-associative values, no named-param risk)

Regression tests cover a payload that mirrors `Message::__serialize()` output and a settings-level associative `headers` map.