### PR TITLE
Add Queue.workerLifetimeJitter to stagger worker shutdowns

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -13,6 +13,9 @@ return [
 		'workerLifetime' => 60, // 1 minutes
 		// Legacy: 'workermaxruntime' is deprecated but still supported
 
+		// optional random offset (0-N seconds) added per worker to stagger shutdowns in a fleet (0 = disabled)
+		'workerLifetimeJitter' => 0,
+
 		// seconds of running time after which the PHP process will terminate, null uses workerLifetime * 2
 		'workerPhpTimeout' => null,
 		// Legacy: 'workertimeout' is deprecated but still supported

--- a/docs/sections/configuration.md
+++ b/docs/sections/configuration.md
@@ -55,7 +55,7 @@ You may create a file called `app_queue.php` inside your `config` folder (NOT th
     $config['Queue']['workerLifetimeJitter'] = 30; // up to +30s random offset per worker
     ```
 
-  Each worker picks a random offset in `[0, workerLifetimeJitter]` at startup and adds it to its effective lifetime. Useful when many workers are spawned simultaneously (e.g. ECS/Kubernetes) to stagger shutdowns and avoid a thundering herd of concurrent restarts. Defaults to `0` (no jitter).
+  Each worker picks a random offset in `[0, workerLifetimeJitter]` at startup and adds it to its effective lifetime. Useful when many workers are spawned simultaneously (e.g. ECS/Kubernetes) to stagger shutdowns and avoid a thundering herd of concurrent restarts. Defaults to `0` (no jitter). If `workerLifetime` or the `--max-runtime` override is `0` (unlimited), this setting has no effect.
 
 - Seconds of running time after which the PHP process of the worker will terminate:
 

--- a/docs/sections/configuration.md
+++ b/docs/sections/configuration.md
@@ -49,6 +49,14 @@ You may create a file called `app_queue.php` inside your `config` folder (NOT th
   bin/cake queue run --max-runtime 300   # Run for 5 minutes
   ```
 
+- Optional per-worker jitter (in seconds) added to the worker lifetime:
+
+    ```php
+    $config['Queue']['workerLifetimeJitter'] = 30; // up to +30s random offset per worker
+    ```
+
+  Each worker picks a random offset in `[0, workerLifetimeJitter]` at startup and adds it to its effective lifetime. Useful when many workers are spawned simultaneously (e.g. ECS/Kubernetes) to stagger shutdowns and avoid a thundering herd of concurrent restarts. Defaults to `0` (no jitter).
+
 - Seconds of running time after which the PHP process of the worker will terminate:
 
     ```php

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -198,12 +198,10 @@ class Processor {
 
 		$startTime = time();
 		$jitterOffset = $this->computeLifetimeJitterOffset();
-		if ($jitterOffset > 0) {
-			$this->io->out('Applying worker lifetime jitter: +' . $jitterOffset . ' seconds');
-		}
+		$maxRuntime = $this->resolveMaxRuntime($config['maxruntime'], $jitterOffset);
 
 		while (!$this->exit) {
-			$this->setPhpTimeout($config['maxruntime']);
+			$this->setPhpTimeout($maxRuntime);
 
 			try {
 				$this->updatePid($pid);
@@ -236,14 +234,6 @@ class Processor {
 				sleep(Config::sleeptime());
 			}
 
-			$workerLifetime = Configure::read('Queue.workerLifetime') ?? Configure::read('Queue.workermaxruntime');
-			if ($workerLifetime === null && $config['maxruntime'] === null) {
-				throw new RuntimeException('Queue.workerLifetime (or deprecated workermaxruntime) config is required');
-			}
-			$maxRuntime = $config['maxruntime'] ?? (int)$workerLifetime;
-			if ($maxRuntime > 0 && $jitterOffset > 0) {
-				$maxRuntime += $jitterOffset;
-			}
 			// check if we are over the maximum runtime and end processing if so.
 			if ($maxRuntime > 0 && (time() - $startTime) >= $maxRuntime) {
 				$this->exit = true;
@@ -649,6 +639,32 @@ class Processor {
 		}
 
 		return mt_rand(0, $jitter);
+	}
+
+	/**
+	 * Resolve the effective worker runtime, applying jitter only to bounded workers.
+	 *
+	 * @param int|null $maxruntime Max runtime in seconds if set via CLI option.
+	 * @param int $jitterOffset Per-worker random offset in seconds.
+	 *
+	 * @throws \RuntimeException
+	 *
+	 * @return int
+	 */
+	protected function resolveMaxRuntime(?int $maxruntime, int $jitterOffset): int {
+		$workerLifetime = Configure::read('Queue.workerLifetime') ?? Configure::read('Queue.workermaxruntime');
+		if ($workerLifetime === null && $maxruntime === null) {
+			throw new RuntimeException('Queue.workerLifetime (or deprecated workermaxruntime) config is required');
+		}
+
+		$resolvedMaxRuntime = $maxruntime ?? (int)$workerLifetime;
+		if ($resolvedMaxRuntime <= 0 || $jitterOffset <= 0) {
+			return (int)$resolvedMaxRuntime;
+		}
+
+		$this->io->out('Applying worker lifetime jitter: +' . $jitterOffset . ' seconds');
+
+		return (int)$resolvedMaxRuntime + $jitterOffset;
 	}
 
 	/**

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -197,6 +197,10 @@ class Processor {
 		$this->exit = false;
 
 		$startTime = time();
+		$jitterOffset = $this->computeLifetimeJitterOffset();
+		if ($jitterOffset > 0) {
+			$this->io->out('Applying worker lifetime jitter: +' . $jitterOffset . ' seconds');
+		}
 
 		while (!$this->exit) {
 			$this->setPhpTimeout($config['maxruntime']);
@@ -237,6 +241,9 @@ class Processor {
 				throw new RuntimeException('Queue.workerLifetime (or deprecated workermaxruntime) config is required');
 			}
 			$maxRuntime = $config['maxruntime'] ?? (int)$workerLifetime;
+			if ($maxRuntime > 0 && $jitterOffset > 0) {
+				$maxRuntime += $jitterOffset;
+			}
 			// check if we are over the maximum runtime and end processing if so.
 			if ($maxRuntime > 0 && (time() - $startTime) >= $maxRuntime) {
 				$this->exit = true;
@@ -624,6 +631,24 @@ class Processor {
 		}
 
 		set_time_limit($timeLimit);
+	}
+
+	/**
+	 * Compute the per-worker lifetime jitter offset in seconds.
+	 *
+	 * Returns a random integer in [0, Queue.workerLifetimeJitter]. Used to stagger
+	 * worker shutdowns so a fleet spawned at the same moment does not all exit
+	 * on the same tick (thundering herd).
+	 *
+	 * @return int
+	 */
+	protected function computeLifetimeJitterOffset(): int {
+		$jitter = (int)Configure::read('Queue.workerLifetimeJitter', 0);
+		if ($jitter <= 0) {
+			return 0;
+		}
+
+		return mt_rand(0, $jitter);
 	}
 
 	/**

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -94,6 +94,28 @@ class ProcessorTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testResolveMaxRuntimeAppliesJitterToBoundedWorkers() {
+		$this->Processor = new Processor(new Io(new ConsoleIo()), new NullLogger());
+
+		$result = $this->invokeMethod($this->Processor, 'resolveMaxRuntime', [30, 7]);
+
+		$this->assertSame(37, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testResolveMaxRuntimeDoesNotApplyJitterToUnlimitedWorkers() {
+		$this->Processor = new Processor(new Io(new ConsoleIo()), new NullLogger());
+
+		$result = $this->invokeMethod($this->Processor, 'resolveMaxRuntime', [0, 7]);
+
+		$this->assertSame(0, $result);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testRun() {
 		$this->_needsConnection();
 

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -442,4 +442,51 @@ class ProcessorTest extends TestCase {
 		Configure::delete('Queue.workertimeout');
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testComputeLifetimeJitterOffsetDefaultsToZero() {
+		$processor = new Processor(new Io(new ConsoleIo()), new NullLogger());
+
+		Configure::delete('Queue.workerLifetimeJitter');
+		$result = $this->invokeMethod($processor, 'computeLifetimeJitterOffset');
+		$this->assertSame(0, $result);
+
+		Configure::write('Queue.workerLifetimeJitter', 0);
+		$result = $this->invokeMethod($processor, 'computeLifetimeJitterOffset');
+		$this->assertSame(0, $result);
+
+		Configure::delete('Queue.workerLifetimeJitter');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testComputeLifetimeJitterOffsetWithinBounds() {
+		$processor = new Processor(new Io(new ConsoleIo()), new NullLogger());
+
+		Configure::write('Queue.workerLifetimeJitter', 15);
+		for ($i = 0; $i < 50; $i++) {
+			$result = $this->invokeMethod($processor, 'computeLifetimeJitterOffset');
+			$this->assertIsInt($result);
+			$this->assertGreaterThanOrEqual(0, $result);
+			$this->assertLessThanOrEqual(15, $result);
+		}
+
+		Configure::delete('Queue.workerLifetimeJitter');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testComputeLifetimeJitterOffsetIgnoresNegative() {
+		$processor = new Processor(new Io(new ConsoleIo()), new NullLogger());
+
+		Configure::write('Queue.workerLifetimeJitter', -10);
+		$result = $this->invokeMethod($processor, 'computeLifetimeJitterOffset');
+		$this->assertSame(0, $result);
+
+		Configure::delete('Queue.workerLifetimeJitter');
+	}
+
 }


### PR DESCRIPTION
## Summary

Adds an optional `Queue.workerLifetimeJitter` config (seconds). Each worker picks a random offset in `[0, workerLifetimeJitter]` at startup and adds it to its effective `workerLifetime` / `--max-runtime`. When a fleet of workers is spawned at the same instant (ECS tasks, Kubernetes deployments, systemd unit with many instances), this prevents every worker from terminating on the same tick and producing a thundering-herd of simultaneous restarts.

Defaults to `0`, so behavior is unchanged unless the option is set.

```php
// config/app.php
$config['Queue']['workerLifetime'] = 300;
$config['Queue']['workerLifetimeJitter'] = 30; // workers now exit between 300s and 330s
```

## Credit

Idea and original implementation by **Rommel Penaflor** ([@xrompdev](https://github.com/xrompdev)) in #475, where it was proposed against a legacy CakePHP 2.x Symphosize fork and therefore could not be merged directly. This PR is a fresh port to the modern `Queue\Queue\Processor`, keeping the operational intent intact.

## Implementation notes

- Jitter is computed **once per worker** (right after `$startTime = time()` in `Processor::run()`), not re-rolled each loop iteration, so the exit time is stable per worker.
- Extracted into `Processor::computeLifetimeJitterOffset()` so the bounds/default behavior is unit-testable without spinning up the full run loop.
- Only applied when `$maxRuntime > 0` — unlimited workers stay unlimited.
- `<= 0` jitter values are ignored (returns 0), so a misconfigured negative value is a no-op rather than an error.
- If jitter was applied, the worker logs `Applying worker lifetime jitter: +Ns seconds` so operators can see the stagger in action.

## Docs

Added a dedicated bullet in `docs/sections/configuration.md` directly after the `workerLifetime` section, explaining the ECS/K8s use case.