### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -188,38 +188,44 @@ use Cake\Core\Configure;
 										</td>
 										<td>
 											<?php if ($this->Queue->hasFailed($pendingJob)): ?>
-												<?= $this->Form->postLink(
+												<?= $this->Form->postButton(
 													'<i class="fas fa-redo"></i>',
 													['action' => 'resetJob', $pendingJob->id],
 													[
 														'escapeTitle' => false,
 														'class' => 'btn btn-sm btn-outline-primary',
-														'confirm' => __d('queue', 'Sure?'),
 														'title' => __d('queue', 'Reset'),
-														'block' => true,
+														'form' => [
+															'class' => 'd-inline',
+															'data-confirm-message' => __d('queue', 'Sure?'),
+														],
 													]
 												) ?>
-												<?= $this->Form->postLink(
+												<?= $this->Form->postButton(
 													'<i class="fas fa-trash"></i>',
 													['action' => 'removeJob', $pendingJob->id],
 													[
 														'escapeTitle' => false,
 														'class' => 'btn btn-sm btn-outline-danger',
-														'confirm' => __d('queue', 'Sure?'),
 														'title' => __d('queue', 'Remove'),
-														'block' => true,
+														'form' => [
+															'class' => 'd-inline',
+															'data-confirm-message' => __d('queue', 'Sure?'),
+														],
 													]
 												) ?>
 											<?php elseif ($pendingJob->fetched): ?>
-												<?= $this->Form->postLink(
+												<?= $this->Form->postButton(
 													'<i class="fas fa-trash"></i>',
 													['action' => 'removeJob', $pendingJob->id],
 													[
 														'escapeTitle' => false,
 														'class' => 'btn btn-sm btn-outline-danger',
-														'confirm' => __d('queue', 'Sure?'),
 														'title' => __d('queue', 'Remove'),
-														'block' => true,
+														'form' => [
+															'class' => 'd-inline',
+															'data-confirm-message' => __d('queue', 'Sure?'),
+														],
 													]
 												) ?>
 											<?php endif; ?>
@@ -276,15 +282,17 @@ use Cake\Core\Configure;
 											<?php endif; ?>
 										</td>
 										<td>
-											<?= $this->Form->postLink(
+											<?= $this->Form->postButton(
 												'<i class="fas fa-trash"></i>',
 												['action' => 'removeJob', $scheduledJob->id],
 												[
 													'escapeTitle' => false,
 													'class' => 'btn btn-sm btn-outline-danger',
-													'confirm' => __d('queue', 'Sure?'),
 													'title' => __d('queue', 'Remove'),
-													'block' => true,
+													'form' => [
+														'class' => 'd-inline',
+														'data-confirm-message' => __d('queue', 'Sure?'),
+													],
 												]
 											) ?>
 										</td>
@@ -365,15 +373,17 @@ use Cake\Core\Configure;
 							}
 							?>
 							<?php $description = $taskDescriptions[$task] ?? null; ?>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-plus me-1"></i>' . h($task),
 								['action' => 'addJob', '?' => ['task' => $task]],
 								[
 									'escapeTitle' => false,
-									'class' => 'btn btn-outline-primary btn-sm text-start',
-									'confirm' => __d('queue', 'Sure?'),
+									'class' => 'btn btn-outline-primary btn-sm text-start w-100',
 									'title' => $description,
-									'block' => true,
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('queue', 'Sure?'),
+									],
 								]
 							) ?>
 						<?php endforeach; ?>
@@ -402,15 +412,17 @@ use Cake\Core\Configure;
 								continue;
 							} ?>
 							<?php $description = $taskDescriptions[$task] ?? null; ?>
-							<?= $this->Form->postLink(
+							<?= $this->Form->postButton(
 								'<i class="fas fa-flask me-1"></i>' . h($task),
 								['action' => 'addJob', '?' => ['task' => $task]],
 								[
 									'escapeTitle' => false,
-									'class' => 'btn btn-outline-secondary btn-sm text-start',
-									'confirm' => __d('queue', 'Sure?'),
+									'class' => 'btn btn-outline-secondary btn-sm text-start w-100',
 									'title' => $description,
-									'block' => true,
+									'form' => [
+										'class' => 'd-inline',
+										'data-confirm-message' => __d('queue', 'Sure?'),
+									],
 								]
 							) ?>
 						<?php endforeach; ?>

--- a/templates/Admin/Queue/processes.php
+++ b/templates/Admin/Queue/processes.php
@@ -55,28 +55,32 @@ use Cake\I18n\DateTime;
 							</div>
 
 							<div class="d-flex gap-2">
-								<?= $this->Form->postLink(
+								<?= $this->Form->postButton(
 									'<i class="fas fa-stop me-1"></i>' . __d('queue', 'Finish & End'),
 									['action' => 'processes', '?' => ['end' => $process->pid]],
 									[
 										'escapeTitle' => false,
 										'class' => 'btn btn-sm btn-outline-warning',
-										'confirm' => __d('queue', 'Sure?'),
 										'title' => __d('queue', 'Finish current job and end worker'),
-										'block' => true,
+										'form' => [
+											'class' => 'd-inline',
+											'data-confirm-message' => __d('queue', 'Sure?'),
+										],
 									]
 								) ?>
 
 								<?php if ($process->workerkey === $key || !$this->Configure->read('Queue.multiserver')): ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-skull me-1"></i>' . __d('queue', 'Kill'),
 										['action' => 'processes', '?' => ['kill' => $process->pid]],
 										[
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-outline-danger',
-											'confirm' => __d('queue', 'Sure? This sends SIGTERM to the process.'),
 											'title' => __d('queue', 'Send SIGTERM to terminate immediately'),
-											'block' => true,
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __d('queue', 'Sure? This sends SIGTERM to the process.'),
+											],
 										]
 									) ?>
 								<?php endif; ?>

--- a/templates/Admin/QueueProcesses/index.php
+++ b/templates/Admin/QueueProcesses/index.php
@@ -19,14 +19,16 @@ use Queue\Queue\Config;
 			['controller' => 'Queue', 'action' => 'processes'],
 			['class' => 'btn btn-outline-primary btn-sm', 'escapeTitle' => false],
 		) ?>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-broom me-1"></i>' . __d('queue', 'Cleanup'),
 			['action' => 'cleanup'],
 			[
 				'class' => 'btn btn-outline-warning btn-sm',
 				'escapeTitle' => false,
-				'confirm' => __d('queue', 'Sure to remove all outdated ones (>{0}s)?', Config::defaultworkertimeout() * 2),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('queue', 'Sure to remove all outdated ones (>{0}s)?', Config::defaultworkertimeout() * 2),
+				],
 			],
 		) ?>
 	</div>
@@ -101,16 +103,18 @@ use Queue\Queue\Config;
 									],
 								) ?>
 								<?php if (!$queueProcess->terminate) : ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-times"></i>',
 										['action' => 'terminate', $queueProcess->id],
 										[
 											'escapeTitle' => false,
 											'class' => 'btn btn-outline-warning',
-											'confirm' => __d('queue', 'Are you sure you want to terminate # {0}?', $queueProcess->id),
 											'title' => __d('queue', 'Terminate'),
 											'aria-label' => __d('queue', 'Terminate'),
-											'block' => true,
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __d('queue', 'Are you sure you want to terminate # {0}?', $queueProcess->id),
+											],
 										],
 									) ?>
 								<?php endif; ?>

--- a/templates/Admin/QueueProcesses/view.php
+++ b/templates/Admin/QueueProcesses/view.php
@@ -80,25 +80,29 @@ use Queue\Queue\Config;
 					['class' => 'list-group-item list-group-item-action', 'escapeTitle' => false]
 				) ?>
 				<?php if (!$queueProcess->terminate): ?>
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-times me-2"></i>' . __d('queue', 'Terminate (Graceful)'),
 						['action' => 'terminate', $queueProcess->id],
 						[
-							'class' => 'list-group-item list-group-item-action text-warning',
+							'class' => 'list-group-item list-group-item-action text-warning btn btn-link text-start w-100',
 							'escapeTitle' => false,
-							'confirm' => __d('queue', 'Are you sure you want to terminate # {0}?', $queueProcess->id),
-							'block' => true,
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('queue', 'Are you sure you want to terminate # {0}?', $queueProcess->id),
+							],
 						]
 					) ?>
 				<?php else: ?>
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-trash me-2"></i>' . __d('queue', 'Delete (Force)'),
 						['action' => 'delete', $queueProcess->id],
 						[
-							'class' => 'list-group-item list-group-item-action text-danger',
+							'class' => 'list-group-item list-group-item-action text-danger btn btn-link text-start w-100',
 							'escapeTitle' => false,
-							'confirm' => __d('queue', 'Are you sure you want to delete # {0}?', $queueProcess->id),
-							'block' => true,
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('queue', 'Are you sure you want to delete # {0}?', $queueProcess->id),
+							],
 						]
 					) ?>
 				<?php endif; ?>

--- a/templates/Admin/QueuedJobs/edit.php
+++ b/templates/Admin/QueuedJobs/edit.php
@@ -42,14 +42,16 @@
 					['action' => 'data', $queuedJob->id],
 					['class' => 'list-group-item list-group-item-action', 'escapeTitle' => false]
 				) ?>
-				<?= $this->Form->postLink(
+				<?= $this->Form->postButton(
 					'<i class="fas fa-trash me-2"></i>' . __d('queue', 'Delete Job'),
 					['action' => 'delete', $queuedJob->id],
 					[
-						'class' => 'list-group-item list-group-item-action text-danger',
+						'class' => 'list-group-item list-group-item-action text-danger btn btn-link text-start w-100',
 						'escapeTitle' => false,
-						'confirm' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
-						'block' => true,
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
+						],
 					]
 				) ?>
 			</div>

--- a/templates/Admin/QueuedJobs/index.php
+++ b/templates/Admin/QueuedJobs/index.php
@@ -216,16 +216,18 @@ if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Sear
 										]
 									) ?>
 								<?php endif; ?>
-								<?= $this->Form->postLink(
+								<?= $this->Form->postButton(
 									'<i class="fas fa-trash"></i>',
 									['action' => 'delete', $queuedJob->id],
 									[
 										'escapeTitle' => false,
 										'class' => 'btn btn-outline-danger',
-										'confirm' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
 										'title' => __d('queue', 'Delete'),
 										'aria-label' => __d('queue', 'Delete'),
-										'block' => true,
+										'form' => [
+											'class' => 'd-inline',
+											'data-confirm-message' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
+										],
 									]
 								) ?>
 							</div>

--- a/templates/Admin/QueuedJobs/stats.php
+++ b/templates/Admin/QueuedJobs/stats.php
@@ -110,7 +110,8 @@ foreach ($stats as $type => $days) {
 ?>
 
 <?php $this->append('script'); ?>
-<script>
+<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var chartCanvas = document.getElementById('job-chart');
 	if (!chartCanvas) return;

--- a/templates/Admin/QueuedJobs/view.php
+++ b/templates/Admin/QueuedJobs/view.php
@@ -21,14 +21,16 @@ use Brick\VarExporter\VarExporter;
 				['class' => 'btn btn-outline-primary', 'escapeTitle' => false]
 			) ?>
 		<?php else: ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-copy me-1"></i>' . __d('queue', 'Clone & Re-run'),
 				['action' => 'clone', $queuedJob->id],
 				[
 					'class' => 'btn btn-outline-success',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure?'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure?'),
+					],
 				]
 			) ?>
 		<?php endif; ?>
@@ -37,14 +39,16 @@ use Brick\VarExporter\VarExporter;
 			['action' => 'view', $queuedJob->id, '_ext' => 'json', '?' => ['download' => true]],
 			['class' => 'btn btn-outline-secondary', 'escapeTitle' => false]
 		) ?>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-trash me-1"></i>' . __d('queue', 'Delete'),
 			['action' => 'delete', $queuedJob->id],
 			[
 				'class' => 'btn btn-outline-danger',
 				'escapeTitle' => false,
-				'confirm' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __d('queue', 'Are you sure you want to delete # {0}?', $queuedJob->id),
+				],
 			]
 		) ?>
 	</div>
@@ -306,26 +310,30 @@ use Brick\VarExporter\VarExporter;
 				<!-- Actions -->
 				<?php if ($this->Queue->hasFailed($queuedJob)): ?>
 					<hr>
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-redo me-1"></i>' . __d('queue', 'Soft Reset'),
 						['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id],
 						[
 							'class' => 'btn btn-primary w-100',
 							'escapeTitle' => false,
-							'confirm' => __d('queue', 'Sure?'),
-							'block' => true,
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('queue', 'Sure?'),
+							],
 						]
 					) ?>
 				<?php elseif (!$queuedJob->completed && $queuedJob->fetched && $queuedJob->attempts && $queuedJob->failure_message): ?>
 					<hr>
-					<?= $this->Form->postLink(
+					<?= $this->Form->postButton(
 						'<i class="fas fa-redo me-1"></i>' . __d('queue', 'Force Reset'),
 						['controller' => 'Queue', 'action' => 'resetJob', $queuedJob->id],
 						[
 							'class' => 'btn btn-warning w-100',
 							'escapeTitle' => false,
-							'confirm' => __d('queue', 'Sure? This job is currently waiting to be re-queued.'),
-							'block' => true,
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __d('queue', 'Sure? This job is currently waiting to be re-queued.'),
+							],
 						]
 					) ?>
 				<?php endif; ?>

--- a/templates/element/Queue/mobile_nav.php
+++ b/templates/element/Queue/mobile_nav.php
@@ -73,44 +73,52 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 	<div>
 		<div class="text-uppercase text-white-50 small mb-2 px-2"><?= __d('queue', 'Quick Actions') ?></div>
 		<nav class="nav flex-column">
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-redo me-2"></i>' . __d('queue', 'Reset Failed'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'reset'],
 				[
-					'class' => 'nav-link text-white py-2',
+					'class' => 'nav-link text-white py-2 btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will make all failed jobs ready for re-run.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will make all failed jobs ready for re-run.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-trash me-2"></i>' . __d('queue', 'Flush Failed'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'flush'],
 				[
-					'class' => 'nav-link text-white py-2',
+					'class' => 'nav-link text-white py-2 btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will remove all failed jobs.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will remove all failed jobs.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-sync me-2"></i>' . __d('queue', 'Reset All'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'reset', '?' => ['full' => true]],
 				[
-					'class' => 'nav-link text-white py-2',
+					'class' => 'nav-link text-white py-2 btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will make all failed as well as still running jobs ready for re-run.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will make all failed as well as still running jobs ready for re-run.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-bomb me-2"></i>' . __d('queue', 'Hard Reset'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'hardReset'],
 				[
-					'class' => 'nav-link text-warning py-2',
+					'class' => 'nav-link text-warning py-2 btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will delete all jobs and completely reset the queue.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will delete all jobs and completely reset the queue.'),
+					],
 				]
 			) ?>
 		</nav>

--- a/templates/element/Queue/sidebar.php
+++ b/templates/element/Queue/sidebar.php
@@ -47,44 +47,52 @@ $isActive = function (string $c, ?array $actions = null) use ($controller, $acti
 	<div class="nav-section">
 		<div class="nav-section-title"><?= __d('queue', 'Quick Actions') ?></div>
 		<nav class="nav flex-column">
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-redo"></i> ' . __d('queue', 'Reset Failed'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'reset'],
 				[
-					'class' => 'nav-link',
+					'class' => 'nav-link btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will make all failed jobs ready for re-run.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will make all failed jobs ready for re-run.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-trash"></i> ' . __d('queue', 'Flush Failed'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'flush'],
 				[
-					'class' => 'nav-link',
+					'class' => 'nav-link btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will remove all failed jobs.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will remove all failed jobs.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-sync"></i> ' . __d('queue', 'Reset All'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'reset', '?' => ['full' => true]],
 				[
-					'class' => 'nav-link',
+					'class' => 'nav-link btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will make all failed as well as still running jobs ready for re-run.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will make all failed as well as still running jobs ready for re-run.'),
+					],
 				]
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-bomb"></i> ' . __d('queue', 'Hard Reset'),
 				['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'hardReset'],
 				[
-					'class' => 'nav-link text-warning',
+					'class' => 'nav-link text-warning btn btn-link text-start w-100',
 					'escapeTitle' => false,
-					'confirm' => __d('queue', 'Sure? This will delete all jobs and completely reset the queue.'),
-					'block' => true,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __d('queue', 'Sure? This will delete all jobs and completely reset the queue.'),
+					],
 				]
 			) ?>
 		</nav>

--- a/templates/layout/queue.php
+++ b/templates/layout/queue.php
@@ -425,7 +425,8 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 	<!-- Bootstrap 5.3.3 JS Bundle -->
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
-	<script>
+	<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+	<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 		document.addEventListener('DOMContentLoaded', function() {
 			// Initialize tooltips
 			var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -445,7 +446,7 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 				});
 			});
 
-			// Confirmation dialogs for postLink forms
+			// Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
 			document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
 				form.addEventListener('submit', function(e) {
 					if (!confirm(this.dataset.confirmMessage)) {


### PR DESCRIPTION
## Summary

- Add `nonce` attribute to the two inline `<script>` blocks (layout initialization, stats chart) so apps with a strict `script-src 'self' 'nonce-...' ...` CSP can run them.
- Replace every `Form->postLink(..., 'confirm' => X)` with `Form->postButton(..., 'form' => ['data-confirm-message' => X])` across all admin templates.
  - `postLink` emits `onclick="..."` on the `<a>`, which CSP blocks without `'unsafe-inline'` / `'unsafe-hashes'`. `nonce` does not cover inline event handlers per the CSP spec.
  - `postButton` emits a `<form>` + `<button type="submit">` — zero inline event handlers. The existing JS delegate in `templates/layout/queue.php` already intercepts `form[data-confirm-message]` submit events and calls `confirm()`, preserving the destructive-action confirmation UX 1:1.
- 26 helper calls migrated across 9 template files. 2 inline scripts now carry nonces.

## Before / after

```diff
- <?= $this->Form->postLink(
-     '<i class="fas fa-trash"></i> ' . __d('queue', 'Flush Failed'),
-     ['action' => 'flush'],
-     [
-         'class' => 'nav-link',
-         'escapeTitle' => false,
-         'confirm' => __d('queue', 'Sure? This will remove all failed jobs.'),
-         'block' => true,
-     ]
- ) ?>
+ <?= $this->Form->postButton(
+     '<i class="fas fa-trash"></i> ' . __d('queue', 'Flush Failed'),
+     ['action' => 'flush'],
+     [
+         'class' => 'nav-link btn btn-link text-start w-100',
+         'escapeTitle' => false,
+         'form' => [
+             'class' => 'd-inline',
+             'data-confirm-message' => __d('queue', 'Sure? This will remove all failed jobs.'),
+         ],
+     ]
+ ) ?>
```

## Host app nonce setup

Apps that want to benefit from the new nonce support need to set a `cspNonce` request attribute in a middleware, for example:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without the `nonce` attribute — apps on permissive CSP continue to work unchanged.

## Visual side-note

`Admin/Queue/index.php` and `Admin/QueueProcesses/index.php` have a `btn-group` that wrapped two adjacent postLinks. Because each `postButton` now wraps its button in `<form class="d-inline">`, Bootstrap's `.btn-group` no longer collapses borders across them. They render as two independent adjacent buttons rather than a connected pair. Functionally identical; visual grouping lost. Mentioning for awareness.

## Verified

- Loaded `/admin/queue` and `/admin/queue/queued-jobs` in Chrome, confirmed 0 inline `onclick` attributes, 24 `form[data-confirm-message]` elements, and confirmation dialog fires as expected on button click with proper localized message.
- Inline scripts carry nonce when `cspNonce` attribute is present on request.