### PR TITLE
Fix silent no-op in Queue::addJob when task does not queue a job

### DIFF
--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -133,13 +133,27 @@ class QueueController extends QueueAppController {
 		}
 
 		$object = new $className();
+		// Measure the QueuedJobs count before invoking the task so we can
+		// tell whether the task actually queued a job. AddInterface::add()
+		// returns void and may silently no-op when required config is
+		// missing (e.g. EmailTask without Config.adminEmail). Without this
+		// check the controller would falsely report success.
+		$before = $this->QueuedJobs->find()->count();
 		if ($object instanceof AddInterface) {
 			$object->add(null);
 		} else {
 			$this->QueuedJobs->createJob($job);
 		}
+		$after = $this->QueuedJobs->find()->count();
 
-		$this->Flash->success('Job ' . $job . ' added');
+		if ($after > $before) {
+			$this->Flash->success('Job ' . $job . ' added');
+		} else {
+			$this->Flash->error(
+				'Job ' . $job . ' could not be added — the task did not create a job. '
+				. 'Check configuration (e.g. Config.adminEmail for Queue.Email) and server logs.',
+			);
+		}
 
 		return $this->refererRedirect(['action' => 'index']);
 	}


### PR DESCRIPTION
## Problem

The admin UI has a "Trigger Jobs" panel that lets operators add demo jobs via `Queue::addJob()`. For tasks implementing `AddInterface`, the action calls `$object->add(null)` and then unconditionally shows `$this->Flash->success('Job X added')`.

But `add()` returns `void`. Some tasks silently do nothing when required configuration is missing. The canonical case is `EmailTask::add()`:

```php
public function add(?string $data): void {
    $adminEmail = Configure::read('Config.adminEmail');
    if ($adminEmail) {
        $this->QueuedJobs->createJob('Queue.Email', $data);
        $this->io->success('OK, job created for email ...');
        return;
    }
    $this->io->warn('Queue Email Task cannot be added via Console without `Config.adminEmail` being set.');
    // ... more $this->io->out() that go to ConsoleIo (invisible in web context)
}
```

When `Config.adminEmail` is not set:
- `add()` writes a warning via `$this->io` (ConsoleIo — invisible in a web request)
- no job is created
- the controller still shows a green success flash

Result: the operator sees "Job Queue.Email added" but no row appears in the queue. Very confusing to debug.

## Fix

Measure the `QueuedJobs` count before and after invoking the task. If the count didn't change, show an error flash instead of a success flash — and point the operator at the likely config gap.

```diff
+$before = $this->QueuedJobs->find()->count();
 if ($object instanceof AddInterface) {
     $object->add(null);
 } else {
     $this->QueuedJobs->createJob($job);
 }
+$after = $this->QueuedJobs->find()->count();

-$this->Flash->success('Job ' . $job . ' added');
+if ($after > $before) {
+    $this->Flash->success('Job ' . $job . ' added');
+} else {
+    $this->Flash->error(
+        'Job ' . $job . ' could not be added — the task did not create a job. '
+        . 'Check configuration (e.g. Config.adminEmail for Queue.Email) and server logs.',
+    );
+}
```

This keeps `AddInterface::add()` non-breaking (still `void`). It's a small count delta check that handles any future task with similar silent-no-op behavior.