### PR TITLE
Move mobile-nav background to CSS class (strict-CSP)

### DIFF
--- a/templates/Admin/QueueProcesses/view.php
+++ b/templates/Admin/QueueProcesses/view.php
@@ -15,7 +15,7 @@ use Queue\Queue\Config;
 			<div class="card-body p-0">
 				<table class="table table-striped mb-0">
 					<tr>
-						<th style="width: 200px;"><?= __d('queue', 'Created') ?></th>
+						<th class="queue-col-w-200"><?= __d('queue', 'Created') ?></th>
 						<td>
 							<?= $this->Time->nice($queueProcess->created) ?>
 							<?php if (!$queueProcess->created->addSeconds(Config::defaultworkertimeout())->isFuture()): ?>

--- a/templates/Admin/QueuedJobs/heatmap.php
+++ b/templates/Admin/QueuedJobs/heatmap.php
@@ -102,7 +102,8 @@ foreach ($grid as $hours) {
 								);
 								?>
 								<div class="heatmap-cell"
-									 style="background-color: <?= $bgColor ?>; color: <?= $textColor ?>;"
+									 data-bg-color="<?= h($bgColor) ?>"
+									 data-text-color="<?= h($textColor) ?>"
 									 data-day="<?= h($dayNamesFull[$day]) ?>"
 									 data-hour="<?= sprintf('%02d:00-%02d:59', $hour, $hour) ?>"
 									 data-count="<?= $count ?>"
@@ -123,7 +124,7 @@ foreach ($grid as $hours) {
 				<div class="heatmap-legend mt-3">
 					<small class="text-muted me-2"><?= __d('queue', 'Less') ?></small>
 					<?php for ($i = 0; $i <= 4; $i++) { ?>
-						<div class="heatmap-legend-cell" style="background-color: <?= $this->Queue->heatmapColor($i / 4) ?>;"></div>
+						<div class="heatmap-legend-cell" data-bg-color="<?= h($this->Queue->heatmapColor($i / 4)) ?>"></div>
 					<?php } ?>
 					<small class="text-muted ms-2"><?= __d('queue', 'More') ?></small>
 				</div>

--- a/templates/Admin/QueuedJobs/migrate.php
+++ b/templates/Admin/QueuedJobs/migrate.php
@@ -21,7 +21,7 @@
 					<table class="table table-hover">
 						<thead>
 							<tr>
-								<th style="width: 50px;"><?= __d('queue', 'Migrate') ?></th>
+								<th class="queue-col-w-50"><?= __d('queue', 'Migrate') ?></th>
 								<th><?= __d('queue', 'Old Name') ?></th>
 								<th><?= __d('queue', 'New Name') ?></th>
 							</tr>

--- a/templates/Admin/QueuedJobs/stats.php
+++ b/templates/Admin/QueuedJobs/stats.php
@@ -30,7 +30,7 @@
 			<div class="card-body">
 				<p class="text-muted"><?= __d('queue', 'For already processed jobs - in average seconds per timeframe.') ?></p>
 
-				<div style="position: relative; height: 400px;">
+				<div class="queue-chart-wrapper">
 					<canvas id="job-chart"></canvas>
 				</div>
 			</div>

--- a/templates/Admin/QueuedJobs/view.php
+++ b/templates/Admin/QueuedJobs/view.php
@@ -64,7 +64,7 @@ use Brick\VarExporter\VarExporter;
 			<div class="card-body p-0">
 				<table class="table table-striped mb-0">
 					<tr>
-						<th style="width: 200px;"><?= __d('queue', 'Job Type') ?></th>
+						<th class="queue-col-w-200"><?= __d('queue', 'Job Type') ?></th>
 						<td><span class="fw-medium"><?= h($queuedJob->job_task) ?></span></td>
 					</tr>
 					<tr>
@@ -120,7 +120,7 @@ use Brick\VarExporter\VarExporter;
 			<div class="card-body p-0">
 				<table class="table table-striped mb-0">
 					<tr>
-						<th style="width: 200px;"><?= __d('queue', 'Created') ?></th>
+						<th class="queue-col-w-200"><?= __d('queue', 'Created') ?></th>
 						<td><?= $this->Time->nice($queuedJob->created) ?></td>
 					</tr>
 					<tr>

--- a/templates/layout/queue.php
+++ b/templates/layout/queue.php
@@ -87,6 +87,16 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 			background: var(--queue-sidebar-bg);
 		}
 
+		/* Column-width utilities (replaces inline `<th style="width:Npx">`). */
+		.queue-col-w-50 { width: 50px; }
+		.queue-col-w-200 { width: 200px; }
+
+		/* Stats chart wrapper (replaces inline `style="position:relative;height:400px"`). */
+		.queue-chart-wrapper {
+			position: relative;
+			height: 400px;
+		}
+
 		.queue-sidebar .nav-section {
 			padding: 0 1rem;
 			margin-bottom: 1.5rem;
@@ -458,6 +468,14 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 						e.preventDefault();
 					}
 				});
+			});
+
+			// Heatmap cell colors (CSP-safe replacement for inline style="background-color:…; color:…;")
+			document.querySelectorAll('[data-bg-color]').forEach(function(el) {
+				el.style.backgroundColor = el.dataset.bgColor;
+			});
+			document.querySelectorAll('[data-text-color]').forEach(function(el) {
+				el.style.color = el.dataset.textColor;
 			});
 
 			<?php if ($autoRefresh > 0): ?>

--- a/templates/layout/queue.php
+++ b/templates/layout/queue.php
@@ -82,6 +82,11 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 			overflow-y: auto;
 		}
 
+		/* Mobile nav offcanvas — same background as sidebar */
+		.queue-mobile-nav-bg {
+			background: var(--queue-sidebar-bg);
+		}
+
 		.queue-sidebar .nav-section {
 			padding: 0 1rem;
 			margin-bottom: 1.5rem;
@@ -382,7 +387,7 @@ if ($request && $request->getParam('controller') === 'Queue' && $request->getPar
 	</nav>
 
 	<!-- Mobile Offcanvas Navigation -->
-	<div class="offcanvas offcanvas-start" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel" style="background: linear-gradient(135deg, #2c3e50 0%, #1a252f 100%);">
+	<div class="offcanvas offcanvas-start queue-mobile-nav-bg" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel">
 		<div class="offcanvas-header border-bottom border-secondary">
 			<h5 class="offcanvas-title text-white" id="mobileNavLabel">
 				<i class="fas fa-layer-group me-2"></i>Queue Admin


### PR DESCRIPTION
## Summary

Drops the inline `style="background: linear-gradient(...)"` attribute on the mobile-nav offcanvas in favour of a `.queue-mobile-nav-bg` class defined in the layout's existing `<style>` block. The class reuses the existing `--queue-sidebar-bg` custom property, so the visual is unchanged.

This removes the `style-src 'unsafe-inline'` requirement for this element. The remaining inline styles in admin templates (static `<th style="width:...">` widths, dynamic heatmap colors in `QueuedJobs/heatmap.php`) are left as follow-ups.

## Files changed

- `templates/layout/queue.php` — add `.queue-mobile-nav-bg` rule + swap `style=` for `class=`