### PR TITLE
Sweep stale queue_processes rows on worker startup

### DIFF
--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -177,7 +177,9 @@ class Processor {
 				$this->io->out('Cannot start worker: Too many workers already/still running on this server (' . $limit . '/' . $limit . ')');
 			}
 
-			$this->QueueProcesses->cleanEndedProcesses();
+			// No retry-sweep here: the pre-sweep above already ran. If
+			// initPid still fails, the limit is genuinely reached and
+			// re-sweeping would not change that.
 
 			return CommandInterface::CODE_ERROR;
 		}
@@ -249,7 +251,10 @@ class Processor {
 			if ($this->exit || mt_rand(0, 100) > 100 - (int)Config::gcprob()) {
 				$this->io->out('Performing Old job cleanup.');
 				$this->QueuedJobs->cleanOldJobs();
-				$this->QueueProcesses->cleanEndedProcesses();
+				// `cleanEndedProcesses()` is no longer called here: it now
+				// runs unconditionally at every worker startup, so the
+				// shutdown sweep is redundant. `cleanOldJobs()` stays —
+				// that's about the queued_jobs table, not workers.
 			}
 			$this->io->hr();
 		}

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -161,6 +161,13 @@ class Processor {
 	public function run(array $args): int {
 		$config = $this->getConfig($args);
 
+		// Sweep stale `queue_processes` rows from prior workers that died
+		// without a graceful shutdown (SIGKILL, OOM, container restart,
+		// etc.). Without this, ghost rows accumulate, count toward the
+		// `Queue.maxworkers` limit and can lock out new workers.
+		// Stale = not updated for `Queue.defaultRequeueTimeout` seconds.
+		$this->QueueProcesses->cleanEndedProcesses();
+
 		try {
 			$pid = $this->initPid();
 		} catch (PersistenceFailedException $exception) {

--- a/tests/TestCase/Model/Table/QueueProcessesTableTest.php
+++ b/tests/TestCase/Model/Table/QueueProcessesTableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Queue\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\I18n\DateTime;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -162,6 +163,79 @@ class QueueProcessesTableTest extends TestCase {
 
 		$queuedProcess = $queuedProcessesTable->get($queuedProcess->id);
 		$this->assertTrue($queuedProcess->terminate);
+	}
+
+	/**
+	 * Stale rows (those whose `modified` timestamp is older than the
+	 * configured `Queue.defaultRequeueTimeout`) belong to workers that
+	 * died without a graceful shutdown. `cleanEndedProcesses()` removes
+	 * them; fresh rows are kept.
+	 *
+	 * @return void
+	 */
+	public function testCleanEndedProcessesRemovesStaleRowsOnly() {
+		Configure::write('Queue.defaultRequeueTimeout', 60);
+
+		// Wipe fixture rows so the test reasons only about its own data.
+		$this->QueueProcesses->deleteAll(['1=1']);
+
+		$stale = $this->QueueProcesses->newEntity(['pid' => '111', 'workerkey' => 'stale-key']);
+		$this->QueueProcesses->saveOrFail($stale);
+		$this->QueueProcesses->updateAll(
+			['modified' => (new DateTime())->subSeconds(120)->toDateTimeString()],
+			['id' => $stale->id],
+		);
+
+		// Fresh: just created, modified == now.
+		$fresh = $this->QueueProcesses->newEntity(['pid' => '222', 'workerkey' => 'fresh-key']);
+		$this->QueueProcesses->saveOrFail($fresh);
+
+		$deleted = $this->QueueProcesses->cleanEndedProcesses();
+
+		$this->assertSame(1, $deleted);
+		$this->assertFalse(
+			$this->QueueProcesses->exists(['pid' => '111']),
+			'Stale row should have been deleted',
+		);
+		$this->assertTrue(
+			$this->QueueProcesses->exists(['pid' => '222']),
+			'Fresh row should be preserved',
+		);
+	}
+
+	/**
+	 * Regression: a worker starting up must sweep stale `queue_processes`
+	 * rows BEFORE attempting to register its own. Without this, a few
+	 * dead-but-uncleaned rows count toward `Queue.maxworkers` and can
+	 * lock out new workers.
+	 *
+	 * @return void
+	 */
+	public function testStaleRowsCountTowardMaxWorkersUntilCleaned() {
+		Configure::write('Queue.maxworkers', 2);
+		Configure::write('Queue.defaultRequeueTimeout', 60);
+
+		$this->QueueProcesses->deleteAll(['1=1']);
+		$server = $this->QueueProcesses->buildServerString();
+
+		// Use add() so `server` is populated as a real worker would.
+		$staleId1 = $this->QueueProcesses->add('111', 'key-111');
+		$staleId2 = $this->QueueProcesses->add('222', 'key-222');
+		$this->QueueProcesses->updateAll(
+			['modified' => (new DateTime())->subSeconds(120)->toDateTimeString()],
+			['id IN' => [$staleId1, $staleId2]],
+		);
+
+		// Without cleanup, validateCount would refuse a third worker.
+		$this->assertSame(2, $this->QueueProcesses->find()->where(['server' => $server])->count());
+
+		$this->QueueProcesses->cleanEndedProcesses();
+
+		$this->assertSame(0, $this->QueueProcesses->find()->where(['server' => $server])->count());
+
+		// And the third worker can now register.
+		$id = $this->QueueProcesses->add('333', 'key-333');
+		$this->assertNotEmpty($id);
 	}
 
 }


### PR DESCRIPTION
## Summary

Workers that die without graceful shutdown (SIGKILL, OOM, container restart, anything that bypasses the SIGTERM handler) leave their `queue_processes` row behind with `terminate=0`. Without intervention these ghost rows accumulate and count toward `Queue.maxworkers` via `QueueProcessesTable::validateCount()`, which can refuse to register new workers (`Too many workers running`) even though the actual processes are long dead.

`cleanEndedProcesses()` already exists and removes any row whose `modified` is older than `Queue.defaultRequeueTimeout`, but it is only invoked from:

- the worker's end-of-loop cleanup, gated by `gcprob` (default 10%, so ~10 minutes between actual sweeps with one-minute worker turnover);
- a fallback inside the `PersistenceFailedException` catch block, which only runs *after* a worker has already failed to start.

Neither path runs before `initPid()`, so the `maxworkers` check sees stale rows. This PR moves an unconditional `cleanEndedProcesses()` call to the top of `Processor::run()` so every fresh worker sweeps dead siblings before attempting to register.

## Reproduction

1. `Queue.maxworkers = 2`, `Queue.defaultRequeueTimeout = 60`
2. Start a worker that picks up a long-running job
3. SIGKILL the worker mid-job (or let the container OOM-kill it)
4. The `queue_processes` row stays with `terminate = 0` and `modified` frozen at the last cycle
5. After 2 such kills the third worker fails to start: `Too many workers running (2/2)`

After this change, the third worker first sweeps the stale rows and proceeds normally.

## Tests

Added to `QueueProcessesTableTest`:

- `testCleanEndedProcessesRemovesStaleRowsOnly` — covers the existing method's threshold logic (no behaviour change here, just coverage that was missing).
- `testStaleRowsCountTowardMaxWorkersUntilCleaned` — regression for the scenario above.

Both pass; existing tests in the file unchanged.

## Risk

Low. `cleanEndedProcesses()` is a single `DELETE WHERE modified < threshold`, runs in milliseconds, and the threshold is the same value already used by the existing call sites. The only behavioural change is *when* it runs — once per worker startup vs. occasionally at worker shutdown.