### PR TITLE
Default-deny admin access via Queue.adminAccess Closure

### DIFF
--- a/docs/sections/admin_dashboard.md
+++ b/docs/sections/admin_dashboard.md
@@ -53,6 +53,40 @@ This is useful when:
 - You want to use the Queue admin without configuring your app's authentication first
 - You're using the plugin in a minimal setup without a full application
 
+### Authorization (`Queue.adminAccess`, required)
+
+The admin UI can trigger jobs (via `AddFromBackendInterface` tasks),
+reset/remove queued jobs, and terminate workers — operational damage if
+exposed. The plugin therefore **fails closed by default**: every request
+to `/admin/queue/...` is rejected with `403` until the host app
+explicitly configures access.
+
+Set `Queue.adminAccess` to a `Closure` that receives the current request
+and returns literal `true` to grant access. Anything else (unset,
+non-`Closure`, returns `false`, returns a truthy non-bool, throws)
+yields a `403`.
+
+```php
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+
+// Example — admin role check (cakephp/authentication identity):
+Configure::write('Queue.adminAccess', function (ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && in_array('admin', (array)$identity->roles, true);
+});
+```
+
+The gate runs in `beforeFilter` for every admin controller in the plugin
+and plays nicely with the cakephp/authorization plugin (it calls
+`skipAuthorization()` so the policy layer doesn't double-reject).
+`ForbiddenException` raised inside the Closure is respected as-is so
+callers can short-circuit with their own message; other throwables are
+logged via `Cake\Log\Log` and converted to a generic `403`.
+
+`Queue.adminAccess` is independent of `Queue.standalone` — the access
+gate runs in both modes.
+
 ### Using Your Application's Layout
 
 To use your application's default layout instead of the isolated Bootstrap 5 layout:

--- a/src/Controller/Admin/QueueAppController.php
+++ b/src/Controller/Admin/QueueAppController.php
@@ -8,15 +8,36 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
 
 /**
  * QueueAppController
  *
  * Base controller for Queue admin.
  *
- * By default, extends AppController to inherit app authentication, components, and configuration.
- * Set `Queue.standalone` to `true` for an isolated admin that doesn't depend on the host app.
+ * Authentication: by default this extends AppController to inherit the host
+ * app's auth and components. Set `Queue.standalone` to `true` for an
+ * isolated admin that does not depend on the host app.
+ *
+ * Authorization: the admin UI can trigger jobs (via AddFromBackendInterface
+ * tasks), reset/remove queued jobs, and terminate workers — operational
+ * damage if exposed. The default policy is **deny**: the host application
+ * MUST set `Queue.adminAccess` to a `Closure` that receives the current
+ * request and returns literal `true` to grant access. Anything else
+ * (unset, non-Closure, returns false, returns a truthy non-bool, or throws)
+ * yields a 403.
+ *
+ * ```php
+ * Configure::write('Queue.adminAccess', function (\Cake\Http\ServerRequest $request): bool {
+ *     $identity = $request->getAttribute('identity');
+ *     return $identity !== null && in_array('admin', (array)$identity->roles, true);
+ * });
+ * ```
  */
 class QueueAppController extends AppController {
 
@@ -57,6 +78,50 @@ class QueueAppController extends AppController {
 		$this->activeConnection = $this->resolveConnection();
 		$this->set('queueConnections', $this->getConnections());
 		$this->set('queueActiveConnection', $this->activeConnection);
+	}
+
+	/**
+	 * Default-deny access gate. The plugin's admin UI can trigger jobs and
+	 * mutate queue state, so accidental exposure (a logged-in but non-admin
+	 * user, or a missing middleware in standalone mode) is treated as harmful
+	 * by default.
+	 *
+	 * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+     *
+	 * @throws \Cake\Http\Exception\ForbiddenException When access is denied or unconfigured.
+     *
+	 * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		// Coexist with cakephp/authorization: the gate IS the authorization
+		// decision for these controllers, so silence the policy check.
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		$gate = Configure::read('Queue.adminAccess');
+		if (!($gate instanceof Closure)) {
+			throw new ForbiddenException(__d(
+				'queue',
+				'Queue admin backend is not configured. Set Queue.adminAccess to a Closure that returns true for permitted callers.',
+			));
+		}
+
+		try {
+			$allowed = $gate($this->request) === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
+		} catch (Throwable $e) {
+			Log::warning(sprintf('Queue.adminAccess threw %s: %s', $e::class, $e->getMessage()));
+
+			throw new ForbiddenException(__d('queue', 'Queue admin access denied.'));
+		}
+
+		if (!$allowed) {
+			throw new ForbiddenException(__d('queue', 'Queue admin access denied.'));
+		}
 	}
 
 	/**

--- a/tests/TestCase/Controller/Admin/QueueAppControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueAppControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Queue\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\TestSuite\IntegrationTestTrait;
+use RuntimeException;
+use Shim\TestSuite\TestCase;
+
+/**
+ * @uses \Queue\Controller\Admin\QueueAppController
+ */
+class QueueAppControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Queue.QueuedJobs',
+		'plugin.Queue.QueueProcesses',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->loadPlugins(['Queue']);
+	}
+
+	/**
+	 * Without a configured Queue.adminAccess gate, the backend must fail
+	 * closed (403). The test bootstrap installs a permissive default; we
+	 * delete it for this test only.
+	 *
+	 * @return void
+	 */
+	public function testAdminAccessUnconfiguredYields403(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::delete('Queue.adminAccess');
+
+		$this->expectException(ForbiddenException::class);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessNonClosureYields403(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('Queue.adminAccess', 'not a closure');
+
+		$this->expectException(ForbiddenException::class);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessClosureFalseYields403(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('Queue.adminAccess', fn () => false);
+
+		$this->expectException(ForbiddenException::class);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessRequiresStrictTrue(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('Queue.adminAccess', fn () => 1);
+
+		$this->expectException(ForbiddenException::class);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessThrowingYields403(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('Queue.adminAccess', function (): bool {
+			throw new RuntimeException('oops');
+		});
+
+		$this->expectException(ForbiddenException::class);
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessExplicitForbiddenIsRespected(): void {
+		$this->disableErrorHandlerMiddleware();
+		Configure::write('Queue.adminAccess', function (): bool {
+			throw new ForbiddenException('custom denial reason');
+		});
+
+		$this->expectException(ForbiddenException::class);
+		$this->expectExceptionMessage('custom denial reason');
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAdminAccessReceivesRequest(): void {
+		$received = null;
+		Configure::write('Queue.adminAccess', function ($request) use (&$received): bool {
+			$received = $request;
+
+			return true;
+		});
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+
+		$this->assertResponseOk();
+		$this->assertNotNull($received);
+		$this->assertStringContainsString('queue', $received->getPath());
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -138,3 +138,8 @@ if (env('FIXTURE_SCHEMA_METADATA')) {
 	$loader = new SchemaLoader();
 	$loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
 }
+
+// Permissive default for test runs. Production installs MUST configure their
+// own Closure (default-deny). Individual tests may override or delete this to
+// exercise the deny path.
+Configure::write('Queue.adminAccess', fn () => true);


### PR DESCRIPTION
## Summary

The Queue admin UI can trigger jobs (via `AddFromBackendInterface` tasks), reset / remove queued jobs, and terminate workers — operational damage if exposed to a non-admin caller. Until now the plugin trusted whatever the host `AppController` did, with no fallback if standalone mode was on.

This PR adds `Queue.adminAccess` as a required `Closure` gate, default-deny — the same pattern used by [cakephp-captcha](https://github.com/dereuromark/cakephp-captcha) and (in flight) the queue-scheduler / workflow / tinyauth-backend plugins.

## Behavior

- **Unset** → `403`. Backend is closed until configured.
- **Non-`Closure`** → `403`. Misconfigured key fails closed.
- **`Closure` returns literal `true`** → request proceeds.
- **`Closure` returns `false` / truthy non-bool** → `403`.
- **`Closure` throws `ForbiddenException`** → respected as-is (caller can short-circuit with their own message).
- **`Closure` throws any other `Throwable`** → logged via `Cake\Log\Log` and converted to a generic `403`.

Independent of `Queue.standalone` — the gate runs in both modes. Calls `Authorization::skipAuthorization()` when the cakephp/authorization component is loaded so the gate doesn't conflict with policy-based authorization.

## Example

```php
use Cake\Core\Configure;
use Cake\Http\ServerRequest;

Configure::write('Queue.adminAccess', function (ServerRequest $request): bool {
    $identity = $request->getAttribute('identity');
    return $identity !== null && in_array('admin', (array)$identity->roles, true);
});
```

## Compatibility

**Backwards-incompatible.** Existing installs that just relied on host gating will start `403`'ing until they add a Closure. Migration is one line in `config/bootstrap.php`. The host's existing admin gating typically lives at the controller layer (`isAuthorized()`, `beforeFilter`) which is bypassed when `Queue.standalone = true`; the new gate closes that footgun.

## Tests

- 172 / 172 existing tests still pass.
- 7 new test cases in `QueueAppControllerTest` cover unset → 403, non-Closure → 403, Closure returns false / truthy non-bool / true, throwing, explicit `ForbiddenException` pass-through, and the request being passed to the Closure.
- `tests/bootstrap.php` installs a permissive `adminAccess` for the suite; individual tests override it.

## Checklist

- [x] phpunit (172/172)
- [x] phpcs clean
- [x] phpstan clean
- [x] Docs updated (`docs/sections/admin_dashboard.md` Authorization subsection)
