### PR TITLE
Restrict EmailTask unserialize to configured Message class

### DIFF
--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -136,7 +136,8 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 			$serialized = $data['serialized'] ?? false;
 
 			if ($serialized) {
-				$this->message = is_array($settings) ? static::unserialize($object, $settings) : unserialize($settings);
+				$allowedClass = is_object($class) ? $class::class : $class;
+				$this->message = is_array($settings) ? static::unserialize($object, $settings) : unserialize($settings, ['allowed_classes' => [$allowedClass]]);
 			} else {
 				/** @var class-string<\Cake\Mailer\Message> $class */
 				$this->message = new $class($settings);


### PR DESCRIPTION
## Issue

`src/Queue/Task/EmailTask.php:139` previously called `unserialize($settings)` without restricting which classes could be reconstructed when a queue job carried legacy raw-serialized settings:

```php
$this->message = is_array($settings)
    ? static::unserialize($object, $settings)
    : unserialize($settings); // <-- gadget-chain risk
```

Even though `$class` is validated to be a `\\Cake\\Mailer\\Message` subclass before instantiation, the unserialize call itself is unconstrained — so a queue job whose `class` is a Message subclass but whose `settings` string contains a serialized gadget-chain class would deserialize that gadget.

Anyone who can enqueue an Email job (typically admin UI users on the QueuedJobs admin) could turn this into RCE if a vulnerable class is on the autoload path.

## Fix

Pin deserialization to the same Message subclass already validated for instantiation:

```diff
+ $allowedClass = is_object($class) ? $class::class : $class;
- ... unserialize($settings);
+ ... unserialize($settings, ['allowed_classes' => [$allowedClass]]);
```

Modern app code that passes `settings` as an array via `EmailTask::serialize()` is unaffected (the array path goes through `createFromArray` instead of `unserialize`).

## Tests

`tests/TestCase/Queue/Task/EmailTaskTest.php` — all 10 tests pass.
