### PR TITLE
Document executeAllowedCommands in app.example and upgrading guide

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -90,6 +90,15 @@ return [
 			//],
 		],
 
+		// Per-command allow-list for Queue.Execute. Required when debug is disabled:
+		// the `command` value MUST appear here verbatim, otherwise ExecuteTask throws
+		// before invoking exec(). Empty/unset in production means every Execute job
+		// is rejected. Has no effect when debug is true.
+		'executeAllowedCommands' => [
+			//'bin/cake',
+			//'/usr/bin/php',
+		],
+
 		// Admin dashboard settings
 
 		// Layout for admin pages:

--- a/docs/sections/upgrading.md
+++ b/docs/sections/upgrading.md
@@ -4,6 +4,14 @@
 ### Events for job lifecycle (v8.4+)
 A new event `Queue.Job.maxAttemptsExhausted` is now dispatched when a job has failed all of its configured retry attempts. This allows you to implement custom handling for permanently failed jobs, such as sending notifications or logging to external services. See the [Events section](misc.md#events) for usage details.
 
+### ExecuteTask security hardening
+`Queue.Execute` now escapes the `command` and each `params` entry per token via `escapeshellarg()` instead of `escapeshellcmd()`, so arguments cannot break out into additional shell tokens (argument injection). It also enforces a `Queue.executeAllowedCommands` allow-list whenever `debug` is disabled: the `command` value MUST appear in the list verbatim, otherwise the task throws before `exec()`. With debug off and the list empty/unset, every Execute job is rejected.
+
+Two follow-ups for callers:
+
+- Callers that previously embedded multiple tokens inside a single `params` entry (e.g. `'params' => ['importer run']`) must split such entries across the array (e.g. `'params' => ['importer', 'run']`). Equivalent: move the leading subcommand into `command`.
+- Production deployments must populate `Queue.executeAllowedCommands` in `config/app.php` (or `app_local.php`) with the exact `command` strings the app is allowed to execute. See `config/app.example.php` and the [Execute task docs](tasks/execute.md).
+
 ## Coming from v7 to v8?
 - Make sure you ran `bin/cake migrations migrate -p Queue` to migrate DB schema for all previous migrations before upgrading to v8.
 - Once upgraded also run it once more, there should be now only 1 migration left.


### PR DESCRIPTION
## Summary

Follow-up to #485. The merged change introduced `Queue.executeAllowedCommands` and a behavior change for callers that previously embedded multiple tokens in a single `params` entry, but neither showed up in the two places users look first.

- `config/app.example.php` is the canonical inventory of every `Queue.*` knob (every other option is listed there with a one-line comment). The new allow-list key is now there too, with a short note that production rejects every Execute job when the list is empty/unset.
- `docs/sections/upgrading.md` now has an `ExecuteTask security hardening` subsection that flags both the param-splitting BC break and the production allow-list requirement, so anyone upgrading from a release prior to #485 sees it before things mysteriously start failing.

No code or logic changes; PHP lint clean on `app.example.php`.