### PR TITLE
Refresh queue.pot from current source

### DIFF
--- a/resources/locales/queue.pot
+++ b/resources/locales/queue.pot
@@ -1,541 +1,745 @@
-# LANGUAGE translation of queue
+# LANGUAGE translation of CakePHP Application
 # Copyright YEAR NAME <EMAIL@ADDRESS>
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: queue \n"
-"POT-Creation-Date: 2025-11-22 10:51+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 04:14+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ./src/View/Helper/QueueHelper.php:86
-msgid "Aborted"
+msgid "Invalid connection: {0}. Must be one of: {1}"
 msgstr ""
 
-#: ./templates/Admin/Queue/index.php:21
-#: ./templates/Admin/QueueProcesses/edit.php:9
-#: ./templates/Admin/QueueProcesses/index.php:10
-#: ./templates/Admin/QueueProcesses/index.php:26
-#: ./templates/Admin/QueueProcesses/view.php:10
-#: ./templates/Admin/QueuedJobs/data.php:9
-#: ./templates/Admin/QueuedJobs/edit.php:9
-#: ./templates/Admin/QueuedJobs/execute.php:8
-#: ./templates/Admin/QueuedJobs/import.php:8
-#: ./templates/Admin/QueuedJobs/index.php:14
-#: ./templates/Admin/QueuedJobs/index.php:51
-#: ./templates/Admin/QueuedJobs/migrate.php:9
-#: ./templates/Admin/QueuedJobs/stats.php:14
-#: ./templates/Admin/QueuedJobs/test.php:10
-#: ./templates/Admin/QueuedJobs/view.php:12
-msgid "Actions"
+msgid "Queue admin backend is not configured. Set Queue.adminAccess to a Closure that returns true for permitted callers."
 msgstr ""
 
-#: ./templates/Admin/QueueProcesses/index.php:24
-#: ./templates/Admin/QueueProcesses/view.php:39
-msgid "Active"
+msgid "Queue admin access denied."
 msgstr ""
 
-#: ./templates/Admin/Queue/processes.php:26
-msgid "Active processes"
+msgid "Invalid connection: {0}"
 msgstr ""
 
-#: ./templates/Admin/QueuedJobs/execute.php:14
-msgid "Add Execute Jobs"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:24
-msgid "All Jobs"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:16
-#: ./templates/Admin/QueuedJobs/edit.php:14
-#: ./templates/Admin/QueuedJobs/index.php:140
-#: ./templates/Admin/QueuedJobs/view.php:21
-msgid "Are you sure you want to delete # {0}?"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/index.php:58
-#: ./templates/Admin/QueueProcesses/view.php:14
-msgid "Are you sure you want to terminate # {0}?"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:98
-#: ./templates/Admin/Queue/index.php:153
-#: ./templates/Admin/QueuedJobs/view.php:109
-msgid "Attempts"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/edit.php:10
-#: ./templates/Admin/QueueProcesses/index.php:12
-#: ./templates/Admin/QueuedJobs/data.php:10
-#: ./templates/Admin/QueuedJobs/edit.php:10
-#: ./templates/Admin/QueuedJobs/migrate.php:10
-msgid "Back"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/migrate.php:18
-msgid "Chose Tasks to migrate"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/index.php:13
-msgid "Cleanup"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:19
-msgid "Clone and re-run"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:69
-msgid "Completed"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/test.php:15
-msgid "Create test jobs"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:79
-#: ./templates/Admin/Queue/index.php:134
-#: ./templates/Admin/QueueProcesses/view.php:26
-#: ./templates/Admin/QueuedJobs/view.php:41
-msgid "Created"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:25
-msgid "Current Queue Processes"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/index.php:23
-msgid "Current server time"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:17
-#: ./templates/Admin/QueueProcesses/index.php:11
-#: ./templates/Admin/QueuedJobs/execute.php:9
-#: ./templates/Admin/QueuedJobs/index.php:15
-#: ./templates/Admin/QueuedJobs/stats.php:15
-#: ./templates/Admin/QueuedJobs/view.php:13
-msgid "Dashboard"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:137
-msgid "Data"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:63
-msgid "Delay"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/edit.php:12
-msgid "Delete"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:16
-msgid "Delete (not advised)"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:21
-msgid "Delete Queued Job"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:187
-msgid "Detailed Statistics"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/index.php:126
-#: ./templates/Admin/QueuedJobs/view.php:100
-msgid "Done"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:74
-msgid "Duration"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/data.php:15
-#: ./templates/Admin/QueuedJobs/edit.php:22
-msgid "Edit"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/edit.php:16
-msgid "Edit PID {0}"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/edit.php:17
-msgid "Edit Payload"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/edit.php:20
-#: ./templates/Admin/QueueProcesses/view.php:11
-msgid "Edit Queue Process"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/edit.php:26
-#: ./templates/Admin/QueuedJobs/view.php:17
-msgid "Edit Queued Job"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/data.php:19
-msgid "Edit Queued Job Payload"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:14
-msgid "Export"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:22
-#: ./templates/Admin/Queue/index.php:23
-msgid "Failed Jobs"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:101
-#: ./templates/Admin/Queue/index.php:156
-#: ./templates/Admin/QueuedJobs/view.php:151
-msgid "Failure Message"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:82
-#: ./templates/Admin/Queue/index.php:137
-#: ./templates/Admin/QueuedJobs/view.php:58
-msgid "Fetched"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:40
-msgid "Finish current job and end"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:23
-msgid "Flush {0}"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:116
-msgid "Force reset"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:25
-msgid "Hard Reset {0}"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/index.php:17
-msgid "Import"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/import.php:17
-msgid "Import Job from exported JSON"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:33
-msgid "Job Group"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/stats.php:26
-msgid "Job Statistics"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:29
-msgid "Job Type"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:42
-msgid "Kill"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/index.php:23
-msgid "Last Run"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:26
-#: ./templates/Admin/Queue/processes.php:18
-#: ./templates/Admin/QueueProcesses/edit.php:11
-#: ./templates/Admin/QueueProcesses/view.php:19
-#: ./templates/Admin/QueuedJobs/data.php:11
-#: ./templates/Admin/QueuedJobs/edit.php:18
-#: ./templates/Admin/QueuedJobs/execute.php:10
-#: ./templates/Admin/QueuedJobs/stats.php:16
-#: ./templates/Admin/QueuedJobs/test.php:11
-#: ./templates/Admin/QueuedJobs/view.php:22
-msgid "List {0}"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:104
-msgid "Memory Usage"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/migrate.php:14
-msgid "Migrate v3 to v4"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:35
-msgid "Modified"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:43
-msgid "Not running"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:45
-msgid "Notbefore"
-msgstr ""
-
-#: ./src/Controller/Admin/QueueController.php:199
-msgid "OK"
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:207
-msgid "Please, try again."
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:131
-msgid "Priority"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:91
-#: ./templates/Admin/Queue/index.php:146
-#: ./templates/Admin/QueuedJobs/view.php:84
-msgid "Progress"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:25
-#: ./templates/Admin/Queue/index.php:31
-#: ./templates/Admin/Queue/processes.php:23
-#: ./templates/Admin/QueuedJobs/stats.php:21
-msgid "Queue"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:18
-#: ./templates/Admin/QueueProcesses/edit.php:11
-#: ./templates/Admin/QueueProcesses/index.php:17
-#: ./templates/Admin/QueueProcesses/view.php:19
-msgid "Queue Processes"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:26
-#: ./templates/Admin/Queue/index.php:56
-#: ./templates/Admin/QueuedJobs/data.php:11
-#: ./templates/Admin/QueuedJobs/edit.php:18
-#: ./templates/Admin/QueuedJobs/execute.php:10
-#: ./templates/Admin/QueuedJobs/index.php:36
-#: ./templates/Admin/QueuedJobs/stats.php:16
-#: ./templates/Admin/QueuedJobs/test.php:11
-#: ./templates/Admin/QueuedJobs/view.php:22
-msgid "Queued Jobs"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:37
-msgid "Reference"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:69
-#: ./templates/Admin/Queue/index.php:71
-#: ./templates/Admin/Queue/index.php:124
-#: ./templates/Admin/Queue/index.php:126
-msgid "Remove"
-msgstr ""
-
-#: ./src/View/Helper/QueueHelper.php:83
-msgid "Requeued"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:22
-#: ./templates/Admin/Queue/index.php:24
-msgid "Reset {0}"
-msgstr ""
-
-#: ./src/View/Helper/QueueHelper.php:78
-msgid "Restarted"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:43
-msgid "Running"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:46
-msgid "Server"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:42
-msgid "Soft kill"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:68
-#: ./templates/Admin/Queue/index.php:123
-#: ./templates/Admin/QueuedJobs/view.php:114
-msgid "Soft reset"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/index.php:22
-msgid "Started"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:167
-msgid "Statistics"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:36
-#: ./templates/Admin/QueuedJobs/view.php:80
-msgid "Status"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/edit.php:25
-#: ./templates/Admin/QueuedJobs/data.php:24
-#: ./templates/Admin/QueuedJobs/edit.php:32
-#: ./templates/Admin/QueuedJobs/execute.php:30
-#: ./templates/Admin/QueuedJobs/import.php:23
-#: ./templates/Admin/QueuedJobs/migrate.php:25
-#: ./templates/Admin/QueuedJobs/test.php:30
-msgid "Submit"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/view.php:19
-msgid "Sure?"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:25
-msgid "Sure? This will delete all jobs and completely reset the queue."
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:24
-msgid "Sure? This will make all failed as well as still running jobs ready for re-run."
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:22
-msgid "Sure? This will make all failed jobs ready for re-run."
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:23
-msgid "Sure? This will remove all failed jobs."
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/index.php:58
-#: ./templates/Admin/QueueProcesses/view.php:14
-msgid "Terminate"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:14
-msgid "Terminate (clean remove)"
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:55
-msgid "Terminated"
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:381
-msgid "The job could not be queued. Please try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueueProcessesController.php:98
-#: ./src/Controller/Admin/QueueProcessesController.php:121
-msgid "The queue process could not be deleted. Please, try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueueProcessesController.php:78
-msgid "The queue process could not be saved. Please, try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueueProcessesController.php:96
-#: ./src/Controller/Admin/QueueProcessesController.php:119
-msgid "The queue process has been deleted."
-msgstr ""
-
-#: ./src/Controller/Admin/QueueProcessesController.php:73
-msgid "The queue process has been saved."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:299
-msgid "The queued job could not be cloned. Please try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:282
-msgid "The queued job could not be deleted. Please try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:234
-#: ./src/Controller/Admin/QueuedJobsController.php:263
-msgid "The queued job could not be saved. Please try again."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:297
-msgid "The queued job has been cloned and will now run."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:280
-msgid "The queued job has been deleted."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:229
-#: ./src/Controller/Admin/QueuedJobsController.php:258
-msgid "The queued job has been saved."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:221
-#: ./src/Controller/Admin/QueuedJobsController.php:250
-msgid "The queued job is already completed."
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:338
-msgid "The requested job has been queued "
-msgstr ""
-
-#: ./src/Controller/Admin/QueuedJobsController.php:376
-msgid "The requested job has been queued."
-msgstr ""
-
-#: ./templates/Admin/Queue/processes.php:56
-msgid "These have been marked as to be terminated after finishing this round"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/test.php:19
-msgid "Trigger Delayed Job"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:258
-msgid "Trigger Delayed Test/Demo Job"
-msgstr ""
-
-#: ./templates/Admin/QueuedJobs/execute.php:18
-msgid "Trigger Execute Job"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:260
-msgid "Trigger Execute Job(s)"
-msgstr ""
-
-#: ./templates/Admin/QueueProcesses/view.php:50
-#: ./templates/Admin/QueuedJobs/view.php:122
-msgid "Workerkey"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:43
-msgid "last {0}"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:76
-#: ./templates/Admin/Queue/index.php:131
-msgid "scheduled {0}"
-msgstr ""
-
-#: ./templates/Admin/Queue/index.php:86
-#: ./templates/Admin/Queue/index.php:141
-msgid "status"
-msgstr ""
-
-#: ./src/Controller/Admin/QueueController.php:184
-msgid "{0} jobs removed"
-msgstr ""
-
-#: ./src/Controller/Admin/QueueController.php:169
 msgid "{0} jobs reset for re-run"
 msgstr ""
 
-#: ./templates/Admin/Queue/index.php:113
-msgid "{0} task(s) are scheduled to run in the future."
+msgid "{0} jobs removed"
 msgstr ""
 
-#: ./templates/Admin/Queue/index.php:58
-msgid "{0} task(s) newly await processing."
+msgid "OK"
+msgstr ""
+
+msgid "The queue process has been saved."
+msgstr ""
+
+msgid "The queue process could not be saved. Please, try again."
+msgstr ""
+
+msgid "The queue process has been deleted."
+msgstr ""
+
+msgid "The queue process could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Please, try again."
+msgstr ""
+
+msgid "The queued job is already completed."
+msgstr ""
+
+msgid "The queued job has been saved."
+msgstr ""
+
+msgid "The queued job could not be saved. Please try again."
+msgstr ""
+
+msgid "The queued job has been deleted."
+msgstr ""
+
+msgid "The queued job could not be deleted. Please try again."
+msgstr ""
+
+msgid "The queued job has been cloned and will now run."
+msgstr ""
+
+msgid "The queued job could not be cloned. Please try again."
+msgstr ""
+
+msgid "The requested job has been queued "
+msgstr ""
+
+msgid "The requested job has been queued."
+msgstr ""
+
+msgid "The job could not be queued. Please try again."
+msgstr ""
+
+msgid "Demonstrates cost management to prevent server overload"
+msgstr ""
+
+msgid "Simple task that outputs to console"
+msgstr ""
+
+msgid "Demonstrates exception handling (always fails)"
+msgstr ""
+
+msgid "Logs server memory and PHP info"
+msgstr ""
+
+msgid "Long-running task (~2 min) with progress bar updates"
+msgstr ""
+
+msgid "Demonstrates retry behavior (fails 3x, succeeds on 4th)"
+msgstr ""
+
+msgid "Creates another Example job upon completion (chaining)"
+msgstr ""
+
+msgid "Only one instance can run at a time across all workers"
+msgstr ""
+
+msgid "Restarted"
+msgstr ""
+
+msgid "Requeued"
+msgstr ""
+
+msgid "Aborted"
+msgstr ""
+
+msgid "Queue Running"
+msgstr ""
+
+msgid "Queue Idle"
+msgstr ""
+
+msgid "Last activity {0}"
+msgstr ""
+
+msgid "{0} worker(s)"
+msgstr ""
+
+msgid "{0} server(s)"
+msgstr ""
+
+msgid "Manage Workers"
+msgstr ""
+
+msgid "No queue status available. Workers may not have started yet."
+msgstr ""
+
+msgid "Scheduled"
+msgstr ""
+
+msgid "Pending"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Pending Jobs"
+msgstr ""
+
+msgid "View All"
+msgstr ""
+
+msgid "Task"
+msgstr ""
+
+msgid "Reference"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Scheduled {0}"
+msgstr ""
+
+msgid "Attempts"
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Sure?"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+msgid "No pending jobs"
+msgstr ""
+
+msgid "Scheduled Jobs"
+msgstr ""
+
+msgid "Scheduled For"
+msgstr ""
+
+msgid "Statistics"
+msgstr ""
+
+msgid "Finished"
+msgstr ""
+
+msgid "Avg. Existence"
+msgstr ""
+
+msgid "Avg. Delay"
+msgstr ""
+
+msgid "Avg. Runtime"
+msgstr ""
+
+msgid "Time Series"
+msgstr ""
+
+msgid "Heatmap"
+msgstr ""
+
+msgid "Trigger Jobs"
+msgstr ""
+
+msgid "Jobs implementing AddFromBackendInterface"
+msgstr ""
+
+msgid "No addable tasks available"
+msgstr ""
+
+msgid "Execute Job"
+msgstr ""
+
+msgid "Test/Demo Jobs"
+msgstr ""
+
+msgid "Trigger Delayed Test Job"
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "Server"
+msgstr ""
+
+msgid "extension"
+msgstr ""
+
+msgid "Runtime Configuration"
+msgstr ""
+
+msgid "No configuration found"
+msgstr ""
+
+msgid "Active Workers"
+msgstr ""
+
+msgid "Current Queue Processes"
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "Current Job"
+msgstr ""
+
+msgid "Idle - waiting for jobs"
+msgstr ""
+
+msgid "Last activity"
+msgstr ""
+
+msgid "Finish & End"
+msgstr ""
+
+msgid "Finish current job and end worker"
+msgstr ""
+
+msgid "Kill"
+msgstr ""
+
+msgid "Send SIGTERM to terminate immediately"
+msgstr ""
+
+msgid "Sure? This sends SIGTERM to the process."
+msgstr ""
+
+msgid "No active workers"
+msgstr ""
+
+msgid "Start a worker using the CLI command"
+msgstr ""
+
+msgid "Termination Pending"
+msgstr ""
+
+msgid "These workers have been marked for termination after finishing their current job"
+msgstr ""
+
+msgid "Pending termination"
+msgstr ""
+
+msgid "View Process History"
+msgstr ""
+
+msgid "Edit Process"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Server Identifier"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Queue Processes"
+msgstr ""
+
+msgid "Cleanup"
+msgstr ""
+
+msgid "Sure to remove all outdated ones (>{0}s)?"
+msgstr ""
+
+msgid "PID"
+msgstr ""
+
+msgid "Started"
+msgstr ""
+
+msgid "Last Run"
+msgstr ""
+
+msgid "Long running process"
+msgstr ""
+
+msgid "Beyond default worker timeout!"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Terminate"
+msgstr ""
+
+msgid "Are you sure you want to terminate # {0}?"
+msgstr ""
+
+msgid "Process Details"
+msgstr ""
+
+msgid "Long running"
+msgstr ""
+
+msgid "Last Modified"
+msgstr ""
+
+msgid "Terminated"
+msgstr ""
+
+msgid "Worker Key"
+msgstr ""
+
+msgid "Terminate (Graceful)"
+msgstr ""
+
+msgid "Delete (Force)"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "Edit Queued Job Payload"
+msgstr ""
+
+msgid "Payload Data (JSON/Serialized)"
+msgstr ""
+
+msgid "Edit Queued Job"
+msgstr ""
+
+msgid "Edit Payload"
+msgstr ""
+
+msgid "Delete Job"
+msgstr ""
+
+msgid "Add Execute Jobs"
+msgstr ""
+
+msgid "Command"
+msgstr ""
+
+msgid "Escape command"
+msgstr ""
+
+msgid "Enable logging"
+msgstr ""
+
+msgid "Expected Exit Code"
+msgstr ""
+
+msgid "Amount of jobs to spawn"
+msgstr ""
+
+msgid "Escaping is recommended to keep on for security."
+msgstr ""
+
+msgid "Create Job"
+msgstr ""
+
+msgid "Sun"
+msgstr ""
+
+msgid "Mon"
+msgstr ""
+
+msgid "Tue"
+msgstr ""
+
+msgid "Wed"
+msgstr ""
+
+msgid "Thu"
+msgstr ""
+
+msgid "Fri"
+msgstr ""
+
+msgid "Sat"
+msgstr ""
+
+msgid "Sunday"
+msgstr ""
+
+msgid "Monday"
+msgstr ""
+
+msgid "Tuesday"
+msgstr ""
+
+msgid "Wednesday"
+msgstr ""
+
+msgid "Thursday"
+msgstr ""
+
+msgid "Friday"
+msgstr ""
+
+msgid "Saturday"
+msgstr ""
+
+msgid "Throughput Summary"
+msgstr ""
+
+msgid "Last {0} days"
+msgstr ""
+
+msgid "Total Jobs"
+msgstr ""
+
+msgid "Avg/Hour"
+msgstr ""
+
+msgid "Peak Hour"
+msgstr ""
+
+msgid "Quietest"
+msgstr ""
+
+msgid "Busiest Day"
+msgstr ""
+
+msgid "Activity Heatmap"
+msgstr ""
+
+msgid "Jobs Created"
+msgstr ""
+
+msgid "Jobs Completed"
+msgstr ""
+
+msgid "Clear Filter"
+msgstr ""
+
+msgid "jobs"
+msgstr ""
+
+msgid "Less"
+msgstr ""
+
+msgid "More"
+msgstr ""
+
+msgid "Filters"
+msgstr ""
+
+msgid "Metric"
+msgstr ""
+
+msgid "Time Range"
+msgstr ""
+
+msgid "Last 7 days"
+msgstr ""
+
+msgid "Last 30 days"
+msgstr ""
+
+msgid "Last 90 days"
+msgstr ""
+
+msgid "Last 180 days"
+msgstr ""
+
+msgid "Last year"
+msgstr ""
+
+msgid "Job Type"
+msgstr ""
+
+msgid "All Types"
+msgstr ""
+
+msgid "Apply"
+msgstr ""
+
+msgid "Back to Dashboard"
+msgstr ""
+
+msgid "Import Job"
+msgstr ""
+
+msgid "JSON File"
+msgstr ""
+
+msgid "Reset job state (clear completed/failed status)"
+msgstr ""
+
+msgid "Import a job from a previously exported JSON file."
+msgstr ""
+
+msgid "Import"
+msgstr ""
+
+msgid "Queued Jobs"
+msgstr ""
+
+msgid "Group"
+msgstr ""
+
+msgid "Fetched"
+msgstr ""
+
+msgid "Completed"
+msgstr ""
+
+msgid "Priority"
+msgstr ""
+
+msgid "Duration"
+msgstr ""
+
+msgid "Done"
+msgstr ""
+
+msgid "Memory Usage"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Migrate v3 to v4"
+msgstr ""
+
+msgid "This will update job task names from the old v3 format to the new v4 format."
+msgstr ""
+
+msgid "Migrate"
+msgstr ""
+
+msgid "Old Name"
+msgstr ""
+
+msgid "New Name"
+msgstr ""
+
+msgid "Migrate Selected"
+msgstr ""
+
+msgid "Job Statistics"
+msgstr ""
+
+msgid "All Jobs"
+msgstr ""
+
+msgid "For already processed jobs - in average seconds per timeframe."
+msgstr ""
+
+msgid "Filter by Job Type"
+msgstr ""
+
+msgid "Job Processing Time (seconds)"
+msgstr ""
+
+msgid "Create Test Job"
+msgstr ""
+
+msgid "-- Select Task --"
+msgstr ""
+
+msgid "Current server time"
+msgstr ""
+
+msgid "Schedule For (Not Before)"
+msgstr ""
+
+msgid "The target time must also be in server timezone."
+msgstr ""
+
+msgid "Job"
+msgstr ""
+
+msgid "Clone & Re-run"
+msgstr ""
+
+msgid "Export"
+msgstr ""
+
+msgid "Job Details"
+msgstr ""
+
+msgid "Job Group"
+msgstr ""
+
+msgid "Workerkey"
+msgstr ""
+
+msgid "Timeline"
+msgstr ""
+
+msgid "Delay"
+msgstr ""
+
+msgid "Data"
+msgstr ""
+
+msgid "Edit Data"
+msgstr ""
+
+msgid "Output"
+msgstr ""
+
+msgid "Failure Message"
+msgstr ""
+
+msgid "Progress"
+msgstr ""
+
+msgid "Soft Reset"
+msgstr ""
+
+msgid "Force Reset"
+msgstr ""
+
+msgid "Sure? This job is currently waiting to be re-queued."
+msgstr ""
+
+msgid "Database Connection"
+msgstr ""
+
+msgid "Connection"
+msgstr ""
+
+msgid "Navigation"
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "Jobs"
+msgstr ""
+
+msgid "Workers (Active)"
+msgstr ""
+
+msgid "Processes (History)"
+msgstr ""
+
+msgid "Quick Actions"
+msgstr ""
+
+msgid "Reset Failed"
+msgstr ""
+
+msgid "Sure? This will make all failed jobs ready for re-run."
+msgstr ""
+
+msgid "Flush Failed"
+msgstr ""
+
+msgid "Sure? This will remove all failed jobs."
+msgstr ""
+
+msgid "Reset All"
+msgstr ""
+
+msgid "Sure? This will make all failed as well as still running jobs ready for re-run."
+msgstr ""
+
+msgid "Hard Reset"
+msgstr ""
+
+msgid "Sure? This will delete all jobs and completely reset the queue."
+msgstr ""
+
+msgid "Page navigation"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+msgid "Search & Filter"
+msgstr ""
+
+msgid "Auto-wildcard mode"
+msgstr ""
+
+msgid "Search (Group/Reference)"
+msgstr ""
+
+msgid "-- All Tasks --"
+msgstr ""
+
+msgid "-- All Statuses --"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Server Time"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- Re-extract `resources/locales/queue.pot` against the current `src/` and `templates/`. The committed POT had 110 msgids; the fresh extract has 244 — 134 strings added in newer code (admin batch ops, scheduler views, the failed/locked job filters, etc.) had no entry, so a German/Japanese/etc. language pack derived from the old POT was missing more than half the plugin's UI.
- Drop the per-string `#: ./src/...` location comments from the previous POT and switch to `--no-location`. Keeps future regeneration diffs tidy — one line move no longer reshuffles every entry's `#:` line.

No code changes — the plugin already uses `__d('queue', ...)` consistently across all 361 calls.

## Verification (local)

- phpunit: 176 / 176 (3 pre-existing deprecations, 5 notices, 7 skipped — all unrelated)
- phpstan: no errors
- phpcs: clean