### PR TITLE
Suppress idle-poll heartbeat unless verbose

### DIFF
--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -228,8 +228,8 @@ class Processor {
 
 			if ($config['verbose']) {
 				$this->log('run', $pid, false);
+				$this->io->out('[' . date('Y-m-d H:i:s') . '] Looking for Job ...');
 			}
-			$this->io->out('[' . date('Y-m-d H:i:s') . '] Looking for Job ...');
 
 			$queuedJob = $this->QueuedJobs->requestJob($this->getTaskConf(), $config['groups'], $config['types']);
 
@@ -239,7 +239,9 @@ class Processor {
 				$this->io->out('nothing to do, exiting.');
 				$this->exit = true;
 			} else {
-				$this->io->out('nothing to do, sleeping.');
+				if ($config['verbose']) {
+					$this->io->out('nothing to do, sleeping.');
+				}
 				sleep(Config::sleeptime());
 			}
 
@@ -256,7 +258,9 @@ class Processor {
 				// shutdown sweep is redundant. `cleanOldJobs()` stays —
 				// that's about the queued_jobs table, not workers.
 			}
-			$this->io->hr();
+			if ($config['verbose']) {
+				$this->io->hr();
+			}
 		}
 
 		$this->deletePid($pid);

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -49,7 +49,9 @@ class RunCommandTest extends TestCase {
 		$this->exec('queue run');
 
 		$output = $this->_out->output();
-		$this->assertStringContainsString('Looking for Job', $output);
+		// Worker loop ran to completion. The per-iteration heartbeat is
+		// verbose-only now, so assert on the always-on termination event.
+		$this->assertStringContainsString('terminating.', $output);
 		$this->assertExitCode(0);
 	}
 
@@ -63,7 +65,7 @@ class RunCommandTest extends TestCase {
 		$this->exec('queue run');
 
 		$output = $this->_out->output();
-		$this->assertStringContainsString('Looking for Job', $output);
+		$this->assertStringContainsString('Running Job of type "Foo"', $output);
 		$this->assertStringContainsString('CakePHP Foo Example.', $output);
 		$this->assertStringContainsString('My TestService', $output);
 		$this->assertExitCode(0);

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -132,6 +132,52 @@ class ProcessorTest extends TestCase {
 	}
 
 	/**
+	 * Without verbose, the idle-poll heartbeat ("Looking for Job ...",
+	 * "nothing to do, sleeping.", and the trailing horizontal rule) must
+	 * stay silent so a quiet queue doesn't spam stdout/log files.
+	 *
+	 * @return void
+	 */
+	public function testRunNonVerboseSuppressesIdlePollOutput() {
+		Configure::write('Queue.exitwhennothingtodo', true);
+
+		$out = new ConsoleOutput();
+		$err = new ConsoleOutput();
+		$this->Processor = new Processor(new Io(new ConsoleIo($out, $err)), new NullLogger());
+
+		$result = $this->Processor->run([]);
+
+		$this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+		$output = $out->output();
+		$this->assertStringNotContainsString('Looking for Job', $output);
+		$this->assertStringNotContainsString('nothing to do, sleeping', $output);
+		$this->assertStringNotContainsString("\n---", $output);
+		// One-shot exit event still fires: that's not steady-state noise.
+		$this->assertStringContainsString('nothing to do, exiting.', $output);
+	}
+
+	/**
+	 * Verbose mode keeps the existing per-iteration heartbeat so operators
+	 * who opt in still see liveness output.
+	 *
+	 * @return void
+	 */
+	public function testRunVerboseShowsIdlePollOutput() {
+		Configure::write('Queue.exitwhennothingtodo', true);
+
+		$out = new ConsoleOutput();
+		$err = new ConsoleOutput();
+		$this->Processor = new Processor(new Io(new ConsoleIo($out, $err)), new NullLogger());
+
+		$result = $this->Processor->run(['verbose' => true]);
+
+		$this->assertSame(CommandInterface::CODE_SUCCESS, $result);
+		$output = $out->output();
+		$this->assertStringContainsString('Looking for Job', $output);
+		$this->assertStringContainsString('nothing to do, exiting.', $output);
+	}
+
+	/**
 	 * Helper method for skipping tests that need a real connection.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

The worker loop in `Processor::run()` prints three lines every `sleeptime()` interval whenever the queue is empty:

- `[YYYY-MM-DD HH:MM:SS] Looking for Job ...`
- `nothing to do, sleeping.`
- a horizontal-rule separator (`---`)

On a mostly-idle worker that's continuous steady-state noise: it fills stdout / log files without conveying anything beyond "still alive". The existing `verbose` flag already gates the structured `log('run', …)` heartbeat, but not these `out()` calls.

This PR moves those three lines behind `$config['verbose']`. Default workers are now silent on empty polls; operators who want the per-iteration heartbeat keep it via `-v` / `--verbose`.

## What is NOT changed

One-shot events stay always-on because they describe state changes, not steady state:

- `nothing to do, exiting.` (when `Queue.exitwhennothingtodo` is set)
- `Running Job of type "..."` / `Job Finished.`
- `Reached runtime of ... terminating.`
- `Performing Old job cleanup.`
- `Applying worker lifetime jitter: ...`

## Background

Spotted while reviewing PR #490, which proposed removing a similar always-on `echo "No messages"` line from a fork's SQS-polling code path. The literal diff didn't apply upstream (different fork, different layout), but the underlying observation — empty polls shouldn't spam logs — is directly applicable to the upstream worker loop.

## Behavior change

For users who relied on the `Looking for Job ...` / `nothing to do, sleeping.` output as a liveness signal: pass `-v` / `--verbose` (or set the equivalent in your worker invocation). No config or option signatures changed.
