### PR TITLE
Add --force flag to queue worker clean

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -59,6 +59,12 @@ class WorkerCommand extends Command {
 			'help' => 'PID (Process/Worker ID)',
 			'required' => false,
 		]);
+		$parser->addOption('force', [
+			'short' => 'f',
+			'help' => 'For `clean`: remove ALL queue_processes rows regardless of last heartbeat. '
+				. 'Use after container restarts when PID reuse blocks new workers from registering.',
+			'boolean' => true,
+		]);
 
 		$parser->setDescription(
 			'Display, end or kill running workers.',
@@ -80,7 +86,7 @@ class WorkerCommand extends Command {
 			$io->out('Actions are:');
 			$io->out('- end: Gracefully end a worker/process, use "all"/"server" for all');
 			$io->out('- kill: Kill a worker/process, use "all"/"server" for all');
-			$io->out('- clean: ');
+			$io->out('- clean: Remove stale processes (use --force to wipe all)');
 			$io->out();
 
 			/** @var array<\Queue\Model\Entity\QueueProcess> $processes */
@@ -110,6 +116,10 @@ class WorkerCommand extends Command {
 		}
 		if ($action === 'clean' && $pid) {
 			$io->abort('Clean action does not have a 2nd argument.');
+		}
+
+		if ($action === 'clean') {
+			return $this->clean($io, (bool)$args->getOption('force'));
 		}
 
 		/** @phpstan-ignore-next-line */
@@ -191,10 +201,21 @@ class WorkerCommand extends Command {
 
 	/**
 	 * @param \Cake\Console\ConsoleIo $io
+	 * @param bool $force If true, ignores the heartbeat threshold and removes
+	 *  every queue_processes row. Recovery path for container restarts where
+	 *  recycled PIDs would otherwise collide with surviving rows.
 	 *
 	 * @return int
 	 */
-	protected function clean(ConsoleIo $io): int {
+	protected function clean(ConsoleIo $io, bool $force = false): int {
+		if ($force) {
+			$io->out('Force-deleting ALL queue_processes rows.');
+			$result = $this->QueueProcesses->cleanEndedProcesses(true);
+			$io->success('Deleted: ' . $result);
+
+			return static::CODE_SUCCESS;
+		}
+
 		$timeout = Config::defaultworkertimeout();
 		if (!$timeout) {
 			$io->abort('You disabled `defaultRequeueTimeout` in config. Aborting.');

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -198,9 +198,17 @@ class QueueProcessesTable extends Table {
 	}
 
 	/**
+	 * @param bool $force If true, removes ALL rows regardless of heartbeat.
+	 *  Use as a recovery tool after container restarts where PIDs may be
+	 *  reused and stale rows would block new workers from registering.
+	 *
 	 * @return int
 	 */
-	public function cleanEndedProcesses(): int {
+	public function cleanEndedProcesses(bool $force = false): int {
+		if ($force) {
+			return $this->deleteAll(['1=1']);
+		}
+
 		$timeout = Config::defaultworkertimeout();
 		$thresholdTime = (new DateTime())->subSeconds($timeout);
 

--- a/tests/TestCase/Model/Table/QueueProcessesTableTest.php
+++ b/tests/TestCase/Model/Table/QueueProcessesTableTest.php
@@ -238,4 +238,26 @@ class QueueProcessesTableTest extends TestCase {
 		$this->assertNotEmpty($id);
 	}
 
+	/**
+	 * `--force` ignores the heartbeat threshold and wipes every row. Recovery
+	 * path for container restarts where the killed worker's row survives with
+	 * a recent `modified` timestamp, so the normal heartbeat-based cleanup
+	 * considers it "still alive."
+	 *
+	 * @return void
+	 */
+	public function testCleanEndedProcessesForceRemovesAllRows() {
+		Configure::write('Queue.maxworkers', 5);
+
+		$this->QueueProcesses->deleteAll(['1=1']);
+		$this->QueueProcesses->add('111', 'key-111');
+		$this->QueueProcesses->add('222', 'key-222');
+		$this->assertSame(2, $this->QueueProcesses->find()->count());
+
+		$deleted = $this->QueueProcesses->cleanEndedProcesses(true);
+
+		$this->assertSame(2, $deleted);
+		$this->assertSame(0, $this->QueueProcesses->find()->count());
+	}
+
 }


### PR DESCRIPTION
## Summary

- Adds `--force` (`-f`) option to `bin/cake queue worker clean`
- Forces deletion of ALL `queue_processes` rows, bypassing the heartbeat-based threshold
- Use case: container restarts where PIDs are reused. The killed worker's row survives with a recent `modified` timestamp, so the heartbeat-based cleanup won't remove it, and the unique `(pid, server)` index makes the new worker crash-loop.

## Why a flag (not auto-recovery)

This is the operator escape hatch — minimal change, opt-in, no behavioral surprise. A follow-up PR will add automatic eviction in `add()` for the common case so this flag becomes rarely needed.