### PR TITLE
Auto-evict stale queue_processes rows on worker startup

### DIFF
--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -148,9 +148,24 @@ class QueueProcessesTable extends Table {
 	 * @return int
 	 */
 	public function add(string $pid, string $key): int {
+		$server = $this->buildServerString();
+
+		// Evict any stale row holding our (pid, server) slot. Common after
+		// container restarts: the killed worker's row survives, and the
+		// unique index on (pid, server) would otherwise reject the insert.
+		// Only rows whose heartbeat is older than `staleHeartbeatThreshold`
+		// are removed, so a live worker on the same PID is never disturbed.
+		$staleThreshold = (new DateTime())->subSeconds(Config::staleHeartbeatThreshold());
+		$this->deleteAll([
+			'pid' => $pid,
+			'server IS' => $server,
+			'workerkey !=' => $key,
+			'modified <' => $staleThreshold,
+		]);
+
 		$data = [
 			'pid' => $pid,
-			'server' => $this->buildServerString(),
+			'server' => $server,
 			'workerkey' => $key,
 		];
 

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -75,6 +75,22 @@ class Config {
 	}
 
 	/**
+	 * Threshold in seconds after which a queue_processes row whose `modified`
+	 * timestamp is older is considered stale by a starting worker. Workers
+	 * heartbeat (refresh `modified`) on every loop iteration, so a row not
+	 * refreshed in ~90s almost certainly belongs to a dead worker — typically
+	 * a container that was force-restarted. This is intentionally much shorter
+	 * than `defaultRequeueTimeout` (which governs in-flight job requeueing).
+	 *
+	 * @return int
+	 */
+	public static function staleHeartbeatThreshold(): int {
+		$threshold = Configure::read('Queue.staleHeartbeatThreshold');
+
+		return $threshold ?? 90;
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function gcprob(): int {

--- a/tests/TestCase/Model/Table/QueueProcessesTableTest.php
+++ b/tests/TestCase/Model/Table/QueueProcessesTableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Queue\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\Database\Exception\QueryException;
 use Cake\I18n\DateTime;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
@@ -236,6 +237,73 @@ class QueueProcessesTableTest extends TestCase {
 		// And the third worker can now register.
 		$id = $this->QueueProcesses->add('333', 'key-333');
 		$this->assertNotEmpty($id);
+	}
+
+	/**
+	 * Container restart scenario: a worker died without cleaning up its
+	 * queue_processes row. A new worker starts with the same recycled PID.
+	 * The stale row's heartbeat is older than `staleHeartbeatThreshold`, so
+	 * `add()` evicts it before inserting — no duplicate-key crash.
+	 *
+	 * @return void
+	 */
+	public function testAddEvictsStaleRowOnSamePidServer() {
+		Configure::write('Queue.maxworkers', 5);
+		$this->QueueProcesses->deleteAll(['1=1']);
+
+		$staleId = $this->QueueProcesses->add('8', 'old-workerkey');
+		$this->QueueProcesses->updateAll(
+			['modified' => (new DateTime())->subSeconds(180)->toDateTimeString()],
+			['id' => $staleId],
+		);
+
+		$newId = $this->QueueProcesses->add('8', 'new-workerkey');
+		$this->assertNotEmpty($newId);
+		$this->assertNotSame($staleId, $newId);
+
+		$survivors = $this->QueueProcesses->find()->where(['pid' => '8'])->all()->toArray();
+		$this->assertCount(1, $survivors);
+		$this->assertSame('new-workerkey', $survivors[0]->workerkey);
+	}
+
+	/**
+	 * If the existing row is fresh (recent heartbeat), it represents a real,
+	 * live worker — eviction would be wrong. The duplicate-key error is the
+	 * correct outcome. `Queue.maxworkers` is raised so `validateCount` cannot
+	 * mask the real source of failure: the (pid, server) unique index fires
+	 * at the DB level as a `QueryException`, not validation.
+	 *
+	 * @return void
+	 */
+	public function testAddDoesNotEvictRecentRowOnSamePidServer() {
+		Configure::write('Queue.maxworkers', 5);
+		$this->QueueProcesses->deleteAll(['1=1']);
+		$this->QueueProcesses->add('8', 'first-workerkey');
+
+		$this->expectException(QueryException::class);
+		$this->QueueProcesses->add('8', 'second-workerkey');
+	}
+
+	/**
+	 * Operators can tune the threshold for unusual heartbeat intervals.
+	 *
+	 * @return void
+	 */
+	public function testAddRespectsCustomStaleHeartbeatThreshold() {
+		Configure::write('Queue.maxworkers', 5);
+		Configure::write('Queue.staleHeartbeatThreshold', 30);
+		$this->QueueProcesses->deleteAll(['1=1']);
+
+		$staleId = $this->QueueProcesses->add('8', 'old-workerkey');
+		$this->QueueProcesses->updateAll(
+			['modified' => (new DateTime())->subSeconds(60)->toDateTimeString()],
+			['id' => $staleId],
+		);
+
+		$newId = $this->QueueProcesses->add('8', 'new-workerkey');
+		$this->assertNotEmpty($newId);
+
+		Configure::delete('Queue.staleHeartbeatThreshold');
 	}
 
 }


### PR DESCRIPTION
## Summary

- New config: `Queue.staleHeartbeatThreshold` (default 90s).
- `QueueProcessesTable::add()` now evicts a stale `(pid, server)` row whose `modified` is older than the threshold **before** attempting the insert.
- Fixes the crash loop on container restarts (FrankenPHP / Docker): killed workers leave orphan rows and the new worker — getting the same recycled PID — fails the unique-index insert.

## Why a separate threshold (not `defaultRequeueTimeout`)

`defaultRequeueTimeout` (default 10 min) is the threshold for treating an in-flight job as abandoned. Deliberately long, to avoid double-execution. Workers heartbeat every loop iteration — far more often. A row not refreshed in ~90s almost certainly belongs to a dead worker, but waiting 10 min before evicting it makes container redeploys painful.

## Caught vs. uncaught exception path

Worth highlighting: the unique `(pid, server)` collision throws `Cake\\Database\\Exception\\QueryException` at the DB level — not `PersistenceFailedException`. The existing catch in `Processor::run()` only handles the latter, so without this PR the worker crashes hard. The new test `testAddDoesNotEvictRecentRowOnSamePidServer` asserts that exact exception type so any future swap of the constraint mechanism is loud.

## Relationship to other PRs

- PR #492 (`--force` flag on `queue worker clean`) is a complementary operator escape hatch.
- A follow-up draft will explore making `workerkey` the canonical identity and dropping the `(pid, server)` unique index entirely; that would make this eviction logic redundant.