### PR TITLE
Cap admin dashboard pending/scheduled details to avoid OOM on backlogs

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -107,6 +107,15 @@ return [
 		// - string: Uses specified layout
 		'adminLayout' => null,
 
+		// Maximum number of pending and scheduled job rows the admin
+		// dashboard materialises and renders. Aggregate tile counts on the
+		// dashboard are still computed via DB count() and reflect the
+		// unbounded totals; only the visible row list is capped. Raise this
+		// for more rows at once, lower it if the page is sluggish on a
+		// large backlog. The cap also keeps DebugKit's Variables panel
+		// from OOM-ing on huge queues.
+		'adminDetailsLimit' => 200,
+
 		// Back-to-App link in the admin header (opt-in). When set, an outline
 		// button appears in the top navbar so admins can escape the
 		// plugin-isolated layout. Accepts anything Router::url() takes — Cake

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -47,16 +47,31 @@ class QueueController extends QueueAppController {
 		$status = $QueueProcesses->status();
 
 		$current = $this->QueuedJobs->getLength();
-		$pendingDetails = $this->QueuedJobs->getPendingStats()->toArray();
-		$new = 0;
-		foreach ($pendingDetails as $pendingDetail) {
-			if ($pendingDetail['fetched'] || $pendingDetail['attempts']) {
-				continue;
-			}
-			$new++;
+
+		// Cap how many pending/scheduled rows we materialise and pass to the
+		// view. Without a cap a backlog of thousands of pending jobs makes
+		// the dashboard explode: heavy per-row HTML in the response, and
+		// DebugKit's Variables panel serialising every entity for its
+		// snapshot can OOM the request. Aggregate tile counts on the
+		// dashboard keep using DB-side count() queries so they reflect the
+		// true totals regardless of the visible-list cap.
+		$detailsLimit = (int)Configure::read('Queue.adminDetailsLimit', 200);
+
+		// +1 row past the cap so we can detect truncation without a second
+		// count query in the small-backlog case.
+		$pendingDetails = $this->QueuedJobs->getPendingStats()->limit($detailsLimit + 1)->toArray();
+		$pendingDetailsTruncated = count($pendingDetails) > $detailsLimit;
+		if ($pendingDetailsTruncated) {
+			array_pop($pendingDetails);
 		}
 
-		$scheduledDetails = $this->QueuedJobs->getScheduledStats()->toArray();
+		$new = $this->QueuedJobs->getNewCount();
+
+		$scheduledDetails = $this->QueuedJobs->getScheduledStats()->limit($detailsLimit + 1)->toArray();
+		$scheduledDetailsTruncated = count($scheduledDetails) > $detailsLimit;
+		if ($scheduledDetailsTruncated) {
+			array_pop($scheduledDetails);
+		}
 
 		$data = $this->QueuedJobs->getStats();
 
@@ -74,7 +89,17 @@ class QueueController extends QueueAppController {
 		$servers = $QueueProcesses->serverList();
 		$workers = $status ? $status['workers'] : 0;
 
-		$scheduledJobs = count($scheduledDetails);
+		// True totals from DB. When the visible list is truncated we need
+		// these for the "showing N of M" hint; when it isn't, they also
+		// happen to match $pendingDetails count (small extra query that
+		// avoids one branch in the derivation below).
+		$totalPending = $pendingDetailsTruncated
+			? $this->QueuedJobs->getPendingCount()
+			: count($pendingDetails);
+		$scheduledJobs = $scheduledDetailsTruncated
+			? $this->QueuedJobs->getScheduledCount()
+			: count($scheduledDetails);
+
 		$runningJobs = $this->QueuedJobs->find()
 			->where([
 				'completed IS' => null,
@@ -89,7 +114,7 @@ class QueueController extends QueueAppController {
 			])
 			->count();
 		// Pending = total pending minus running and failed (to avoid double counting)
-		$pendingJobs = max(0, count($pendingDetails) - $runningJobs - $failedJobs);
+		$pendingJobs = max(0, $totalPending - $runningJobs - $failedJobs);
 
 		$configurations = (array)Configure::read('Queue');
 
@@ -99,6 +124,10 @@ class QueueController extends QueueAppController {
 			'data',
 			'pendingDetails',
 			'scheduledDetails',
+			'pendingDetailsTruncated',
+			'scheduledDetailsTruncated',
+			'detailsLimit',
+			'totalPending',
 			'status',
 			'tasks',
 			'addableTasks',

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -1041,6 +1041,46 @@ class QueuedJobsTable extends Table {
 	}
 
 	/**
+	 * Count of pending jobs (matches getPendingStats() conditions).
+	 *
+	 * Companion to getPendingStats() for callers that LIMIT the materialised
+	 * details list and need the unbounded total to render "showing N of M".
+	 *
+	 * @return int
+	 */
+	public function getPendingCount(): int {
+		return $this->find()
+			->where([
+				'completed IS' => null,
+				'OR' => [
+					'notbefore <=' => new DateTime(),
+					'notbefore IS' => null,
+				],
+			])
+			->count();
+	}
+
+	/**
+	 * Count of pending jobs that have never been fetched or attempted
+	 * (the "new" tile on the admin dashboard).
+	 *
+	 * @return int
+	 */
+	public function getNewCount(): int {
+		return $this->find()
+			->where([
+				'completed IS' => null,
+				'fetched IS' => null,
+				'attempts' => 0,
+				'OR' => [
+					'notbefore <=' => new DateTime(),
+					'notbefore IS' => null,
+				],
+			])
+			->count();
+	}
+
+	/**
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function getScheduledStats(): SelectQuery {
@@ -1066,6 +1106,23 @@ class QueuedJobsTable extends Table {
 		];
 
 		return $this->find('all', ...$findCond);
+	}
+
+	/**
+	 * Count of scheduled jobs (matches getScheduledStats() conditions).
+	 *
+	 * Companion to getScheduledStats() for callers that LIMIT the
+	 * materialised details list and need the unbounded total.
+	 *
+	 * @return int
+	 */
+	public function getScheduledCount(): int {
+		return $this->find()
+			->where([
+				'completed IS' => null,
+				'notbefore >' => new DateTime(),
+			])
+			->count();
 	}
 
 	/**

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -139,7 +139,7 @@ use Cake\Core\Configure;
 								$totalPending,
 								$this->Html->link(
 									__d('queue', 'See QueuedJobs admin'),
-									['controller' => 'QueuedJobs', 'action' => 'index'],
+									['controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'in_progress']],
 								),
 							],
 						) ?>
@@ -277,8 +277,15 @@ use Cake\Core\Configure;
 							<i class="fas fa-info-circle me-1"></i>
 							<?= __d(
 								'queue',
-								'Showing {0} most recent of {1} scheduled jobs.',
-								[count($scheduledDetails), $scheduledJobs],
+								'Showing {0} most recent of {1} scheduled jobs. {2} for the full list.',
+								[
+									count($scheduledDetails),
+									$scheduledJobs,
+									$this->Html->link(
+										__d('queue', 'See QueuedJobs admin'),
+										['controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'scheduled']],
+									),
+								],
 							) ?>
 						</div>
 					<?php endif; ?>

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -1,8 +1,12 @@
 <?php
 /**
  * @var \App\View\AppView $this
- * @var \Queue\Model\Entity\QueuedJob[] $pendingDetails
- * @var \Queue\Model\Entity\QueuedJob[] $scheduledDetails
+ * @var \Queue\Model\Entity\QueuedJob[] $pendingDetails Capped at $detailsLimit rows.
+ * @var \Queue\Model\Entity\QueuedJob[] $scheduledDetails Capped at $detailsLimit rows.
+ * @var bool $pendingDetailsTruncated True when the pending list was capped.
+ * @var bool $scheduledDetailsTruncated True when the scheduled list was capped.
+ * @var int $detailsLimit Configured cap for the visible pending/scheduled rows.
+ * @var int $totalPending True (uncapped) pending-jobs count.
  * @var string[] $tasks
  * @var string[] $addableTasks
  * @var array<string, string|null> $taskDescriptions
@@ -124,6 +128,23 @@ use Cake\Core\Configure;
 				) ?>
 			</div>
 			<div class="card-body p-0">
+				<?php if ($pendingDetailsTruncated): ?>
+					<div class="alert alert-info mb-0 small rounded-0 border-0 border-bottom">
+						<i class="fas fa-info-circle me-1"></i>
+						<?= __d(
+							'queue',
+							'Showing {0} most recent of {1} pending jobs. {2} for the full list.',
+							[
+								count($pendingDetails),
+								$totalPending,
+								$this->Html->link(
+									__d('queue', 'See QueuedJobs admin'),
+									['controller' => 'QueuedJobs', 'action' => 'index'],
+								),
+							],
+						) ?>
+					</div>
+				<?php endif; ?>
 				<?php if ($pendingDetails): ?>
 					<div class="table-responsive">
 						<table class="table table-hover mb-0">
@@ -248,9 +269,19 @@ use Cake\Core\Configure;
 		<?php if ($scheduledDetails): ?>
 			<div class="card mb-4">
 				<div class="card-header">
-					<i class="fas fa-calendar me-2"></i><?= __d('queue', 'Scheduled Jobs') ?> (<?= count($scheduledDetails) ?>)
+					<i class="fas fa-calendar me-2"></i><?= __d('queue', 'Scheduled Jobs') ?> (<?= $scheduledJobs ?>)
 				</div>
 				<div class="card-body p-0">
+					<?php if ($scheduledDetailsTruncated): ?>
+						<div class="alert alert-info mb-0 small rounded-0 border-0 border-bottom">
+							<i class="fas fa-info-circle me-1"></i>
+							<?= __d(
+								'queue',
+								'Showing {0} most recent of {1} scheduled jobs.',
+								[count($scheduledDetails), $scheduledJobs],
+							) ?>
+						</div>
+					<?php endif; ?>
 					<div class="table-responsive">
 						<table class="table table-hover mb-0">
 							<thead>

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -72,6 +72,52 @@ class QueueControllerTest extends TestCase {
 	}
 
 	/**
+	 * The pending/scheduled detail lists must be capped to
+	 * Queue.adminDetailsLimit so the dashboard renders a bounded amount of
+	 * markup and DebugKit's Variables panel doesn't OOM on large backlogs.
+	 *
+	 * @return void
+	 */
+	public function testIndexTruncatesPendingDetailsAtDetailsLimit() {
+		Configure::write('Queue.adminDetailsLimit', 3);
+
+		$QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
+		for ($i = 0; $i < 5; $i++) {
+			$QueuedJobs->createJob('Queue.Example', ['n' => $i]);
+		}
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$pendingDetails = $this->viewVariable('pendingDetails');
+		$this->assertCount(3, $pendingDetails);
+		$this->assertTrue($this->viewVariable('pendingDetailsTruncated'));
+		$this->assertSame(5, $this->viewVariable('totalPending'));
+		$this->assertSame(3, $this->viewVariable('detailsLimit'));
+	}
+
+	/**
+	 * The truncation flag must stay false when the backlog fits inside the
+	 * cap — otherwise the "Showing N of M" hint would render unnecessarily
+	 * and the controller would issue an extra count() it doesn't need.
+	 *
+	 * @return void
+	 */
+	public function testIndexNotTruncatedWhenWithinLimit() {
+		Configure::write('Queue.adminDetailsLimit', 200);
+
+		$QueuedJobs = $this->fetchTable('Queue.QueuedJobs');
+		$QueuedJobs->createJob('Queue.Example');
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'Queue', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$this->assertFalse($this->viewVariable('pendingDetailsTruncated'));
+		$this->assertFalse($this->viewVariable('scheduledDetailsTruncated'));
+		$this->assertSame(1, $this->viewVariable('totalPending'));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testProcesses() {


### PR DESCRIPTION
## Problem

`QueueController::index()` unconditionally materialises every pending and every scheduled queued_jobs row, then passes both arrays to the view. With a realistic backlog (thousands of pending or failed-and-retried jobs) two things go wrong:

- the rendered Bootstrap-card table grows linearly with rows and is heavy per row
- DebugKit's Variables panel serialises every view variable and can blow past memory_limit (saw a 175MB allocation attempt at 10k rows)

## Fix

- Cap visible pending/scheduled lists at `Queue.adminDetailsLimit` (default 200). New config key documented in `config/app.example.php`.
- Detect truncation with a `+1` row probe so we avoid a second `count()` query on small queues.
- Aggregate tile counts ("new", "pending", "scheduled") computed via DB `count()` against the same conditions so they keep reflecting the true totals regardless of the visible-list cap.
- New companion getters on `QueuedJobsTable`: `getPendingCount()`, `getScheduledCount()`, `getNewCount()`. Pair with the existing `getPendingStats()` / `getScheduledStats()` `SelectQuery` getters.
- Template renders a "Showing N most recent of M" notice when a list is truncated, with a pre-filtered link to the QueuedJobs admin (`?status=in_progress` for pending, `?status=scheduled` for scheduled) so the admin lands on exactly the rows the truncated list represents.

## Tests

- `testIndexTruncatesPendingDetailsAtDetailsLimit` — sets the cap to 3, queues 5 jobs, asserts the truncation flag plus the true total.
- `testIndexNotTruncatedWhenWithinLimit` — single job, asserts truncation flags stay false (avoids the extra count() query in the common case).

Both branches green: 16 tests / 40 assertions.