### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Command/AddCommand.php
+++ b/src/Command/AddCommand.php
@@ -59,7 +59,7 @@ class AddCommand extends Command {
 		$taskName = $args->getArgument('task');
 		if (!$taskName) {
 			$io->out(count($tasks) . ' tasks available:');
-			foreach ($tasks as $task => $className) {
+			foreach (array_keys($tasks) as $task) {
 				$io->out(' - ' . $task);
 			}
 

--- a/src/Command/BakeQueueTaskCommand.php
+++ b/src/Command/BakeQueueTaskCommand.php
@@ -86,12 +86,12 @@ class BakeQueueTaskCommand extends SimpleBakeCommand {
 		}
 		$taskClassNamespace = $namespace . '\Queue\\Task\\' . str_replace(DS, '\\', $name);
 
-		if (strpos($name, '/') !== false) {
+		if (str_contains($name, '/')) {
 			$parts = explode('/', $name);
 			$name = array_pop($parts);
 		}
 
-		$content = <<<TXT
+		return <<<TXT
 <?php
 
 namespace $namespace\Test\TestCase\Queue\Task$subNamespace;
@@ -122,8 +122,6 @@ class $testName extends TestCase {
 }
 
 TXT;
-
-		return $content;
 	}
 
 	/**
@@ -148,7 +146,7 @@ TXT;
 		$namespace .= '\\Queue\\Task';
 
 		$namespacePart = null;
-		if (strpos($name, '/') !== false) {
+		if (str_contains($name, '/')) {
 			$parts = explode('/', $name);
 			$name = array_pop($parts);
 			$namespacePart = implode('\\', $parts);

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -59,7 +59,7 @@ class InfoCommand extends Command {
 		$addableTasks = $this->getAddableTasks();
 
 		$io->out(count($tasks) . ' tasks available:');
-		foreach ($tasks as $task => $className) {
+		foreach (array_keys($tasks) as $task) {
 			if (array_key_exists($task, $addableTasks)) {
 				$task .= ' <info>[addable via CLI]</info>';
 			}

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -28,11 +28,7 @@ trait LoadHelperTrait {
 		}
 
 		// Configure helper: prefer Shim, fallback to Queue's own
-		if (Plugin::isLoaded('Shim')) {
-			$helpers[] = 'Shim.Configure';
-		} else {
-			$helpers[] = 'Queue.Configure';
-		}
+		$helpers[] = Plugin::isLoaded('Shim') ? 'Shim.Configure' : 'Queue.Configure';
 
 		if (Configure::read('Icon.sets') && class_exists(IconHelper::class)) {
 			$helpers[] = 'Templating.Icon';

--- a/src/Controller/Admin/QueueAppController.php
+++ b/src/Controller/Admin/QueueAppController.php
@@ -111,6 +111,8 @@ class QueueAppController extends AppController {
 
 		try {
 			$allowed = $gate($this->request) === true;
+		} catch (ForbiddenException $e) {
+			throw $e;
 		} catch (Throwable $e) {
 			Log::warning(sprintf('Queue.adminAccess threw %s: %s', $e::class, $e->getMessage()));
 

--- a/src/Controller/Admin/QueueAppController.php
+++ b/src/Controller/Admin/QueueAppController.php
@@ -111,8 +111,6 @@ class QueueAppController extends AppController {
 
 		try {
 			$allowed = $gate($this->request) === true;
-		} catch (ForbiddenException $e) {
-			throw $e;
 		} catch (Throwable $e) {
 			Log::warning(sprintf('Queue.adminAccess threw %s: %s', $e::class, $e->getMessage()));
 

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -118,7 +118,28 @@ class QueueController extends QueueAppController {
 
 		$configurations = (array)Configure::read('Queue');
 
-		$this->set(['new' => $new, 'current' => $current, 'data' => $data, 'pendingDetails' => $pendingDetails, 'scheduledDetails' => $scheduledDetails, 'pendingDetailsTruncated' => $pendingDetailsTruncated, 'scheduledDetailsTruncated' => $scheduledDetailsTruncated, 'detailsLimit' => $detailsLimit, 'totalPending' => $totalPending, 'status' => $status, 'tasks' => $tasks, 'addableTasks' => $addableTasks, 'taskDescriptions' => $taskDescriptions, 'servers' => $servers, 'workers' => $workers, 'pendingJobs' => $pendingJobs, 'scheduledJobs' => $scheduledJobs, 'runningJobs' => $runningJobs, 'failedJobs' => $failedJobs, 'configurations' => $configurations]);
+		$this->set(compact(
+			'new',
+			'current',
+			'data',
+			'pendingDetails',
+			'scheduledDetails',
+			'pendingDetailsTruncated',
+			'scheduledDetailsTruncated',
+			'detailsLimit',
+			'totalPending',
+			'status',
+			'tasks',
+			'addableTasks',
+			'taskDescriptions',
+			'servers',
+			'workers',
+			'pendingJobs',
+			'scheduledJobs',
+			'runningJobs',
+			'failedJobs',
+			'configurations',
+		));
 	}
 
 	/**

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -118,28 +118,7 @@ class QueueController extends QueueAppController {
 
 		$configurations = (array)Configure::read('Queue');
 
-		$this->set(compact(
-			'new',
-			'current',
-			'data',
-			'pendingDetails',
-			'scheduledDetails',
-			'pendingDetailsTruncated',
-			'scheduledDetailsTruncated',
-			'detailsLimit',
-			'totalPending',
-			'status',
-			'tasks',
-			'addableTasks',
-			'taskDescriptions',
-			'servers',
-			'workers',
-			'pendingJobs',
-			'scheduledJobs',
-			'runningJobs',
-			'failedJobs',
-			'configurations',
-		));
+		$this->set(['new' => $new, 'current' => $current, 'data' => $data, 'pendingDetails' => $pendingDetails, 'scheduledDetails' => $scheduledDetails, 'pendingDetailsTruncated' => $pendingDetailsTruncated, 'scheduledDetailsTruncated' => $scheduledDetailsTruncated, 'detailsLimit' => $detailsLimit, 'totalPending' => $totalPending, 'status' => $status, 'tasks' => $tasks, 'addableTasks' => $addableTasks, 'taskDescriptions' => $taskDescriptions, 'servers' => $servers, 'workers' => $workers, 'pendingJobs' => $pendingJobs, 'scheduledJobs' => $scheduledJobs, 'runningJobs' => $runningJobs, 'failedJobs' => $failedJobs, 'configurations' => $configurations]);
 	}
 
 	/**
@@ -249,7 +228,7 @@ class QueueController extends QueueAppController {
 		$terminated = $QueueProcesses->find()->where(['terminate' => true])->all()->toArray();
 		$key = $QueueProcesses->buildServerString();
 
-		$this->set(compact('terminated', 'processes', 'key'));
+		$this->set(['terminated' => $terminated, 'processes' => $processes, 'key' => $key]);
 	}
 
 	/**
@@ -307,7 +286,7 @@ class QueueController extends QueueAppController {
 		if (is_array($url)) {
 			throw new NotFoundException('Invalid array in query string');
 		}
-		if ($url && (mb_substr($url, 0, 1) !== '/' || mb_substr($url, 0, 2) === '//')) {
+		if ($url && (mb_substr((string) $url, 0, 1) !== '/' || mb_substr((string) $url, 0, 2) === '//')) {
 			$url = null;
 		}
 

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -286,7 +286,7 @@ class QueueController extends QueueAppController {
 		if (is_array($url)) {
 			throw new NotFoundException('Invalid array in query string');
 		}
-		if ($url && (mb_substr((string) $url, 0, 1) !== '/' || mb_substr((string) $url, 0, 2) === '//')) {
+		if ($url && (mb_substr((string)$url, 0, 1) !== '/' || mb_substr((string)$url, 0, 2) === '//')) {
 			$url = null;
 		}
 

--- a/src/Controller/Admin/QueueController.php
+++ b/src/Controller/Admin/QueueController.php
@@ -249,7 +249,7 @@ class QueueController extends QueueAppController {
 		$terminated = $QueueProcesses->find()->where(['terminate' => true])->all()->toArray();
 		$key = $QueueProcesses->buildServerString();
 
-		$this->set(['terminated' => $terminated, 'processes' => $processes, 'key' => $key]);
+		$this->set(compact('terminated', 'processes', 'key'));
 	}
 
 	/**

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -48,7 +48,7 @@ class QueueProcessesController extends QueueAppController {
 	public function index() {
 		$queueProcesses = $this->paginate();
 
-		$this->set(compact('queueProcesses'));
+		$this->set(['queueProcesses' => $queueProcesses]);
 	}
 
 	/**
@@ -61,7 +61,7 @@ class QueueProcessesController extends QueueAppController {
 	public function view(?int $id = null) {
 		$queueProcess = $this->QueueProcesses->get($id);
 
-		$this->set(compact('queueProcess'));
+		$this->set(['queueProcess' => $queueProcess]);
 	}
 
 	/**
@@ -84,7 +84,7 @@ class QueueProcessesController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The queue process could not be saved. Please, try again.'));
 		}
 
-		$this->set(compact('queueProcess'));
+		$this->set(['queueProcess' => $queueProcess]);
 	}
 
 	/**
@@ -100,7 +100,7 @@ class QueueProcessesController extends QueueAppController {
 			$queueProcess->terminate = true;
 			$this->QueueProcesses->saveOrFail($queueProcess);
 			$this->Flash->success(__d('queue', 'The queue process has been deleted.'));
-		} catch (Exception $exception) {
+		} catch (Exception) {
 			$this->Flash->error(__d('queue', 'The queue process could not be deleted. Please, try again.'));
 		}
 

--- a/src/Controller/Admin/QueueProcessesController.php
+++ b/src/Controller/Admin/QueueProcessesController.php
@@ -48,7 +48,7 @@ class QueueProcessesController extends QueueAppController {
 	public function index() {
 		$queueProcesses = $this->paginate();
 
-		$this->set(['queueProcesses' => $queueProcesses]);
+		$this->set(compact('queueProcesses'));
 	}
 
 	/**
@@ -61,7 +61,7 @@ class QueueProcessesController extends QueueAppController {
 	public function view(?int $id = null) {
 		$queueProcess = $this->QueueProcesses->get($id);
 
-		$this->set(['queueProcess' => $queueProcess]);
+		$this->set(compact('queueProcess'));
 	}
 
 	/**
@@ -84,7 +84,7 @@ class QueueProcessesController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The queue process could not be saved. Please, try again.'));
 		}
 
-		$this->set(['queueProcess' => $queueProcess]);
+		$this->set(compact('queueProcess'));
 	}
 
 	/**

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -75,7 +75,7 @@ class QueuedJobsController extends QueueAppController {
 		}
 		$queuedJobs = $this->paginate($query);
 
-		$this->set(compact('queuedJobs'));
+		$this->set(['queuedJobs' => $queuedJobs]);
 
 		if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Search')) {
 			$jobTypes = $this->QueuedJobs->find()->where()->find(
@@ -83,7 +83,7 @@ class QueuedJobsController extends QueueAppController {
 				keyField: 'job_task',
 				valueField: 'job_task',
 			)->distinct('job_task')->toArray();
-			$this->set(compact('jobTypes'));
+			$this->set(['jobTypes' => $jobTypes]);
 		}
 	}
 
@@ -112,7 +112,7 @@ class QueuedJobsController extends QueueAppController {
 			keyField: 'job_task',
 			valueField: 'job_task',
 		)->distinct('job_task')->toArray();
-		$this->set(compact('stats', 'jobTypes', 'jobType'));
+		$this->set(['stats' => $stats, 'jobTypes' => $jobTypes, 'jobType' => $jobType]);
 	}
 
 	/**
@@ -153,7 +153,7 @@ class QueuedJobsController extends QueueAppController {
 			valueField: 'job_task',
 		)->distinct('job_task')->toArray();
 
-		$this->set(compact('heatmapData', 'jobTypes', 'jobType', 'metric', 'days'));
+		$this->set(['heatmapData' => $heatmapData, 'jobTypes' => $jobTypes, 'jobType' => $jobType, 'metric' => $metric, 'days' => $days]);
 	}
 
 	/**
@@ -173,7 +173,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->response = $this->response->withDownload('queued-job-' . $id . '.json');
 		}
 
-		$this->set(compact('queuedJob'));
+		$this->set(['queuedJob' => $queuedJob]);
 		$this->viewBuilder()->setOption('serialize', ['queuedJob']);
 	}
 
@@ -286,7 +286,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The queued job could not be saved. Please try again.'));
 		}
 
-		$this->set(compact('queuedJob'));
+		$this->set(['queuedJob' => $queuedJob]);
 	}
 
 	/**
@@ -322,7 +322,7 @@ class QueuedJobsController extends QueueAppController {
 			}
 		}
 
-		$this->set(compact('queuedJob'));
+		$this->set(['queuedJob' => $queuedJob]);
 	}
 
 	/**
@@ -407,7 +407,7 @@ class QueuedJobsController extends QueueAppController {
 		$taskFinder = new TaskFinder();
 		$allTasks = $taskFinder->all();
 		$tasks = [];
-		foreach ($allTasks as $task => $className) {
+		foreach (array_keys($allTasks) as $task) {
 			if (!str_starts_with($task, 'Queue.')) {
 				continue;
 			}
@@ -440,7 +440,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The job could not be queued. Please try again.'));
 		}
 
-		$this->set(compact('tasks', 'queuedJob'));
+		$this->set(['tasks' => $tasks, 'queuedJob' => $queuedJob]);
 	}
 
 	/**
@@ -458,7 +458,7 @@ class QueuedJobsController extends QueueAppController {
 			->toArray();
 
 		$tasks = [];
-		foreach ($allTasks as $task => $className) {
+		foreach (array_keys($allTasks) as $task) {
 			if (!str_starts_with($task, 'Queue.')) {
 				continue;
 			}
@@ -488,7 +488,7 @@ class QueuedJobsController extends QueueAppController {
 			return $this->redirect(['action' => 'migrate']);
 		}
 
-		$this->set(compact('tasks'));
+		$this->set(['tasks' => $tasks]);
 	}
 
 }

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -75,7 +75,7 @@ class QueuedJobsController extends QueueAppController {
 		}
 		$queuedJobs = $this->paginate($query);
 
-		$this->set(['queuedJobs' => $queuedJobs]);
+		$this->set(compact('queuedJobs'));
 
 		if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Search')) {
 			$jobTypes = $this->QueuedJobs->find()->where()->find(
@@ -83,7 +83,7 @@ class QueuedJobsController extends QueueAppController {
 				keyField: 'job_task',
 				valueField: 'job_task',
 			)->distinct('job_task')->toArray();
-			$this->set(['jobTypes' => $jobTypes]);
+			$this->set(compact('jobTypes'));
 		}
 	}
 
@@ -173,7 +173,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->response = $this->response->withDownload('queued-job-' . $id . '.json');
 		}
 
-		$this->set(['queuedJob' => $queuedJob]);
+		$this->set(compact('queuedJob'));
 		$this->viewBuilder()->setOption('serialize', ['queuedJob']);
 	}
 
@@ -286,7 +286,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The queued job could not be saved. Please try again.'));
 		}
 
-		$this->set(['queuedJob' => $queuedJob]);
+		$this->set(compact('queuedJob'));
 	}
 
 	/**
@@ -322,7 +322,7 @@ class QueuedJobsController extends QueueAppController {
 			}
 		}
 
-		$this->set(['queuedJob' => $queuedJob]);
+		$this->set(compact('queuedJob'));
 	}
 
 	/**
@@ -488,7 +488,7 @@ class QueuedJobsController extends QueueAppController {
 			return $this->redirect(['action' => 'migrate']);
 		}
 
-		$this->set(['tasks' => $tasks]);
+		$this->set(compact('tasks'));
 	}
 
 }

--- a/src/Controller/Admin/QueuedJobsController.php
+++ b/src/Controller/Admin/QueuedJobsController.php
@@ -112,7 +112,7 @@ class QueuedJobsController extends QueueAppController {
 			keyField: 'job_task',
 			valueField: 'job_task',
 		)->distinct('job_task')->toArray();
-		$this->set(['stats' => $stats, 'jobTypes' => $jobTypes, 'jobType' => $jobType]);
+		$this->set(compact('stats', 'jobTypes', 'jobType'));
 	}
 
 	/**
@@ -153,7 +153,7 @@ class QueuedJobsController extends QueueAppController {
 			valueField: 'job_task',
 		)->distinct('job_task')->toArray();
 
-		$this->set(['heatmapData' => $heatmapData, 'jobTypes' => $jobTypes, 'jobType' => $jobType, 'metric' => $metric, 'days' => $days]);
+		$this->set(compact('heatmapData', 'jobTypes', 'jobType', 'metric', 'days'));
 	}
 
 	/**
@@ -440,7 +440,7 @@ class QueuedJobsController extends QueueAppController {
 			$this->Flash->error(__d('queue', 'The job could not be queued. Please try again.'));
 		}
 
-		$this->set(['tasks' => $tasks, 'queuedJob' => $queuedJob]);
+		$this->set(compact('tasks', 'queuedJob'));
 	}
 
 	/**

--- a/src/Generator/Task/QueuedJobTask.php
+++ b/src/Generator/Task/QueuedJobTask.php
@@ -24,7 +24,7 @@ class QueuedJobTask implements TaskInterface {
 		$list = [];
 
 		$names = $this->collectQueuedJobTasks();
-		foreach ($names as $name => $className) {
+		foreach (array_keys($names) as $name) {
 			$list[$name] = "'$name'";
 		}
 
@@ -44,9 +44,8 @@ class QueuedJobTask implements TaskInterface {
 	 */
 	protected function collectQueuedJobTasks(): array {
 		$taskFinder = new TaskFinder();
-		$tasks = $taskFinder->all();
 
-		return $tasks;
+		return $taskFinder->all();
 	}
 
 }

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -57,7 +57,6 @@ class SimpleQueueTransport extends AbstractTransport {
 		];
 
 		foreach ($settings as $setting => $value) {
-			/** @phpstan-ignore-next-line */
 			if ($value[0] === null || $value[0] === []) {
 				unset($settings[$setting]);
 			}

--- a/src/Mailer/Transport/SimpleQueueTransport.php
+++ b/src/Mailer/Transport/SimpleQueueTransport.php
@@ -58,7 +58,7 @@ class SimpleQueueTransport extends AbstractTransport {
 
 		foreach ($settings as $setting => $value) {
 			/** @phpstan-ignore-next-line */
-			if (array_key_exists(0, $value) && ($value[0] === null || $value[0] === [])) {
+			if ($value[0] === null || $value[0] === []) {
 				unset($settings[$setting]);
 			}
 		}

--- a/src/Model/Behavior/JsonableBehavior.php
+++ b/src/Model/Behavior/JsonableBehavior.php
@@ -174,7 +174,7 @@ class JsonableBehavior extends Behavior {
 	public function _encode($val) {
 		if (!empty($this->_config['fields']) && $this->_config['input'] === 'json') {
 			if (!is_string($val)) {
-					throw new InvalidArgumentException('Only accepts JSON string for input type `json`');
+				throw new InvalidArgumentException('Only accepts JSON string for input type `json`');
 			}
 			$val = $this->_fromJson($val);
 		}

--- a/src/Model/Behavior/JsonableBehavior.php
+++ b/src/Model/Behavior/JsonableBehavior.php
@@ -172,14 +172,12 @@ class JsonableBehavior extends Behavior {
 	 * @return string|null
 	 */
 	public function _encode($val) {
-		if (!empty($this->_config['fields'])) {
-			if ($this->_config['input'] === 'json') {
-				if (!is_string($val)) {
+		if (!empty($this->_config['fields']) && $this->_config['input'] === 'json') {
+            if (!is_string($val)) {
 					throw new InvalidArgumentException('Only accepts JSON string for input type `json`');
 				}
-				$val = $this->_fromJson($val);
-			}
-		}
+            $val = $this->_fromJson($val);
+        }
 		if (!is_array($val)) {
 			return null;
 		}

--- a/src/Model/Behavior/JsonableBehavior.php
+++ b/src/Model/Behavior/JsonableBehavior.php
@@ -173,11 +173,11 @@ class JsonableBehavior extends Behavior {
 	 */
 	public function _encode($val) {
 		if (!empty($this->_config['fields']) && $this->_config['input'] === 'json') {
-            if (!is_string($val)) {
+			if (!is_string($val)) {
 					throw new InvalidArgumentException('Only accepts JSON string for input type `json`');
-				}
-            $val = $this->_fromJson($val);
-        }
+			}
+			$val = $this->_fromJson($val);
+		}
 		if (!is_array($val)) {
 			return null;
 		}

--- a/src/Model/Table/QueueProcessesTable.php
+++ b/src/Model/Table/QueueProcessesTable.php
@@ -242,6 +242,7 @@ class QueueProcessesTable extends Table {
 			->enableHydration(false)
 			->all()
 			->toArray();
+		/** @var array<array{modified: \Cake\I18n\DateTime}> $results */
 
 		if (!$results) {
 			return [];

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -267,7 +267,7 @@ class QueuedJobsTable extends Table {
 	 * @return string
 	 */
 	protected function jobTask(string $jobType): string {
-		if ($this->taskFinder === null) {
+		if (!$this->taskFinder instanceof \Queue\Queue\TaskFinder) {
 			$this->taskFinder = new TaskFinder();
 		}
 
@@ -981,7 +981,7 @@ class QueuedJobsTable extends Table {
 
 			// MySQL DAYOFWEEK returns 1=Sunday, 2=Monday, etc. Adjust to 0=Sunday
 			if ($driverName === static::DRIVER_MYSQL) {
-				$day = $day - 1;
+				$day -= 1;
 			}
 
 			// Ensure day is in valid range (0-6)
@@ -1260,10 +1260,9 @@ class QueuedJobsTable extends Table {
 	 * @return string
 	 */
 	protected function getDriverName(): string {
-		$className = explode('\\', $this->getConnection()->config()['driver']);
-		$name = end($className) ?: '';
+		$className = explode('\\', (string) $this->getConnection()->config()['driver']);
 
-		return $name;
+		return end($className) ?: '';
 	}
 
 	/**
@@ -1277,7 +1276,7 @@ class QueuedJobsTable extends Table {
 		$include = [];
 		$exclude = [];
 		foreach ($values as $value) {
-			if (substr($value, 0, 1) === '-') {
+			if (str_starts_with($value, '-')) {
 				$exclude[] = substr($value, 1);
 			} else {
 				$include[] = $value;

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -267,7 +267,7 @@ class QueuedJobsTable extends Table {
 	 * @return string
 	 */
 	protected function jobTask(string $jobType): string {
-		if (!$this->taskFinder instanceof TaskFinder) {
+		if (!($this->taskFinder instanceof TaskFinder)) {
 			$this->taskFinder = new TaskFinder();
 		}
 

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -221,6 +221,7 @@ class QueuedJobsTable extends Table {
 				throw new InvalidArgumentException('createJob() with `unique` requires a `reference` to dedupe on.');
 			}
 
+			/** @var \Queue\Model\Entity\QueuedJob|null $existing */
 			$existing = $this->find()
 				->where([
 					'reference' => $config->getReferenceOrFail(),
@@ -451,6 +452,7 @@ class QueuedJobsTable extends Table {
 			->limit(static::STATS_LIMIT)
 			->all()
 			->toArray();
+		/** @var array<array{created: \DateTime, duration: int|float|null, job_task: string}> $jobs */
 
 		$result = [];
 

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -267,7 +267,7 @@ class QueuedJobsTable extends Table {
 	 * @return string
 	 */
 	protected function jobTask(string $jobType): string {
-		if (!$this->taskFinder instanceof \Queue\Queue\TaskFinder) {
+		if (!$this->taskFinder instanceof TaskFinder) {
 			$this->taskFinder = new TaskFinder();
 		}
 
@@ -1260,7 +1260,7 @@ class QueuedJobsTable extends Table {
 	 * @return string
 	 */
 	protected function getDriverName(): string {
-		$className = explode('\\', (string) $this->getConnection()->config()['driver']);
+		$className = explode('\\', (string)$this->getConnection()->config()['driver']);
 
 		return end($className) ?: '';
 	}

--- a/src/Queue/Config.php
+++ b/src/Queue/Config.php
@@ -27,7 +27,7 @@ class Config {
 				);
 			}
 		}
-		$timeout = $timeout ?? 600; // 10min default
+		$timeout ??= 600; // 10min default
 
 		if ($timeout <= 0) {
 			throw new InvalidArgumentException('Queue.defaultRequeueTimeout (or deprecated defaultworkertimeout) is less or equal than zero. Indefinite running of jobs is not supported.');

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -198,10 +198,10 @@ class Processor {
 			pcntl_async_signals(true);
 		}
 		if (function_exists('pcntl_signal')) {
-			pcntl_signal(SIGTERM, [&$this, 'exit']);
-			pcntl_signal(SIGINT, [&$this, 'abort']);
-			pcntl_signal(SIGTSTP, [&$this, 'abort']);
-			pcntl_signal(SIGQUIT, [&$this, 'abort']);
+			pcntl_signal(SIGTERM, $this->exit(...));
+			pcntl_signal(SIGINT, $this->abort(...));
+			pcntl_signal(SIGTSTP, $this->abort(...));
+			pcntl_signal(SIGQUIT, $this->abort(...));
 			if (Configure::read('Queue.canInterruptSleep')) {
 				// Defining a signal handler here will make the worker wake up
 				// from its sleep() when SIGUSR1 is received. Since waking it
@@ -222,12 +222,12 @@ class Processor {
 
 			try {
 				$this->updatePid($pid);
-			} catch (RecordNotFoundException $exception) {
+			} catch (RecordNotFoundException) {
 				// Manually killed
 				$this->exit = true;
 
 				continue;
-			} catch (ProcessEndingException $exception) {
+			} catch (ProcessEndingException) {
 				// Soft killed, e.g. during deploy update
 				$this->exit = true;
 
@@ -533,13 +533,7 @@ class Processor {
 	 * @return string
 	 */
 	protected function retrievePid(): string {
-		if (function_exists('posix_getpid')) {
-			$pid = (string)posix_getpid();
-		} else {
-			$pid = $this->QueuedJobs->key();
-		}
-
-		return $pid;
+		return function_exists('posix_getpid') ? (string)posix_getpid() : $this->QueuedJobs->key();
 	}
 
 	/**

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -98,7 +98,7 @@ abstract class Task implements TaskInterface {
 		$QueuedJobs = $tableLocator->get($this->queueModelClass);
 		$this->QueuedJobs = $QueuedJobs;
 
-		if (isset($this->defaultTable)) {
+		if (property_exists($this, 'defaultTable') && $this->defaultTable !== null) {
 			$this->fetchTable();
 		}
 	}

--- a/src/Queue/Task.php
+++ b/src/Queue/Task.php
@@ -98,7 +98,7 @@ abstract class Task implements TaskInterface {
 		$QueuedJobs = $tableLocator->get($this->queueModelClass);
 		$this->QueuedJobs = $QueuedJobs;
 
-		if (property_exists($this, 'defaultTable') && $this->defaultTable !== null) {
+		if (isset($this->defaultTable)) {
 			$this->fetchTable();
 		}
 	}

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -205,7 +205,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 		}
 
 		foreach ($settings as $method => $setting) {
-			$setter = 'set' . ucfirst((string) $method);
+			$setter = 'set' . ucfirst((string)$method);
 			if (in_array($method, ['theme', 'template', 'layout'], true)) {
 				call_user_func_array([$this->mailer->viewBuilder(), $setter], (array)$setting);
 

--- a/src/Queue/Task/EmailTask.php
+++ b/src/Queue/Task/EmailTask.php
@@ -205,7 +205,7 @@ class EmailTask extends Task implements AddInterface, AddFromBackendInterface {
 		}
 
 		foreach ($settings as $method => $setting) {
-			$setter = 'set' . ucfirst($method);
+			$setter = 'set' . ucfirst((string) $method);
 			if (in_array($method, ['theme', 'template', 'layout'], true)) {
 				call_user_func_array([$this->mailer->viewBuilder(), $setter], (array)$setting);
 

--- a/src/Queue/Task/ExecuteTask.php
+++ b/src/Queue/Task/ExecuteTask.php
@@ -106,11 +106,7 @@ class ExecuteTask extends Task implements AddInterface {
 			}
 		}
 
-		if ($data['escape']) {
-			$command = escapeshellarg($rawCommand);
-		} else {
-			$command = $rawCommand;
-		}
+		$command = $data['escape'] ? escapeshellarg($rawCommand) : $rawCommand;
 
 		if ($data['params']) {
 			$params = $data['params'];

--- a/src/Queue/Task/MonitorExampleTask.php
+++ b/src/Queue/Task/MonitorExampleTask.php
@@ -102,7 +102,7 @@ class MonitorExampleTask extends Task implements AddInterface, AddFromBackendInt
 		$data = explode("\n", file_get_contents('/proc/meminfo') ?: '');
 		$meminfo = [];
 		foreach ($data as $line) {
-			if (strpos($line, ':') === false) {
+			if (!str_contains($line, ':')) {
 				continue;
 			}
 			[$key, $val] = explode(':', $line);

--- a/src/Queue/Task/ProgressExampleTask.php
+++ b/src/Queue/Task/ProgressExampleTask.php
@@ -75,7 +75,7 @@ class ProgressExampleTask extends Task implements AddInterface, AddFromBackendIn
 	public function run(array $data, int $jobId): void {
 		$this->io->hr();
 		$this->io->out('CakePHP Queue ProgressExample task.');
-		$seconds = !empty($data['duration']) ? (int)$data['duration'] : 2 * static::MINUTE;
+		$seconds = empty($data['duration']) ? 2 * static::MINUTE : (int)$data['duration'];
 
 		$this->io->out('A total of ' . $seconds . ' seconds need to pass...');
 		for ($i = 0; $i < $seconds; $i++) {

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -145,7 +145,7 @@ class TaskFinder {
 
 		if (!str_contains($jobTask, '\\')) {
 			// Let's try matching without plugin prefix
-			foreach ($all as $name => $className) {
+			foreach (array_keys($all) as $name) {
 				if (!str_contains($name, '.')) {
 					continue;
 				}

--- a/src/Queue/TaskFinder.php
+++ b/src/Queue/TaskFinder.php
@@ -145,7 +145,7 @@ class TaskFinder {
 
 		if (!str_contains($jobTask, '\\')) {
 			// Let's try matching without plugin prefix
-			foreach (array_keys($all) as $name) {
+			foreach ($all as $name => $_) {
 				if (!str_contains($name, '.')) {
 					continue;
 				}

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -36,7 +36,8 @@ class QueueHelper extends Helper {
 
 		// Requeued
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-        return !($taskConfig && $queuedJob->attempts <= $taskConfig['retries']);
+
+		return !($taskConfig && $queuedJob->attempts <= $taskConfig['retries']);
 	}
 
 	/**
@@ -81,7 +82,8 @@ class QueueHelper extends Helper {
 		}
 
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-        return $taskConfig && $queuedJob->attempts <= $taskConfig['retries'];
+
+		return $taskConfig && $queuedJob->attempts <= $taskConfig['retries'];
 	}
 
 	/**
@@ -103,8 +105,9 @@ class QueueHelper extends Helper {
 		if ($queuedJob->attempts < 1) {
 			return false;
 		}
-        // Must NOT have a failure_message (it was cleared by reset)
-        return !$queuedJob->failure_message;
+
+		// Must NOT have a failure_message (it was cleared by reset)
+		return !$queuedJob->failure_message;
 	}
 
 	/**

--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -36,11 +36,7 @@ class QueueHelper extends Helper {
 
 		// Requeued
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-		if ($taskConfig && $queuedJob->attempts <= $taskConfig['retries']) {
-			return false;
-		}
-
-		return true;
+        return !($taskConfig && $queuedJob->attempts <= $taskConfig['retries']);
 	}
 
 	/**
@@ -85,11 +81,7 @@ class QueueHelper extends Helper {
 		}
 
 		$taskConfig = $this->taskConfig($queuedJob->job_task);
-		if ($taskConfig && $queuedJob->attempts <= $taskConfig['retries']) {
-			return true;
-		}
-
-		return false;
+        return $taskConfig && $queuedJob->attempts <= $taskConfig['retries'];
 	}
 
 	/**
@@ -111,13 +103,8 @@ class QueueHelper extends Helper {
 		if ($queuedJob->attempts < 1) {
 			return false;
 		}
-
-		// Must NOT have a failure_message (it was cleared by reset)
-		if ($queuedJob->failure_message) {
-			return false;
-		}
-
-		return true;
+        // Must NOT have a failure_message (it was cleared by reset)
+        return !$queuedJob->failure_message;
 	}
 
 	/**

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -78,7 +78,7 @@ class RunCommandTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -78,7 +78,7 @@ class RunCommandTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -349,7 +349,7 @@ class QueueControllerTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Controller/Admin/QueueControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueControllerTest.php
@@ -349,7 +349,7 @@ class QueueControllerTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -433,7 +433,7 @@ JSON,
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -433,7 +433,7 @@ JSON,
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -323,8 +323,10 @@ class QueuedJobsTableTest extends TestCase {
 	/**
      * Test creating Jobs to run close to a specified time, and strtotime parsing.
      * Using toUnixString() function to convert Time object to timestamp, instead of strtotime
+     *
+     * @return void
      */
-    public function testNotBefore() {
+	public function testNotBefore() {
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Min']));
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Day']));
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '2009-07-01 12:00:00']));
@@ -943,7 +945,7 @@ class QueuedJobsTableTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -321,12 +321,10 @@ class QueuedJobsTableTest extends TestCase {
 	}
 
 	/**
-	 * Test creating Jobs to run close to a specified time, and strtotime parsing.
-	 * Using toUnixString() function to convert Time object to timestamp, instead of strtotime
-	 *
-	 * @return null
-	 */
-	public function testNotBefore() {
+     * Test creating Jobs to run close to a specified time, and strtotime parsing.
+     * Using toUnixString() function to convert Time object to timestamp, instead of strtotime
+     */
+    public function testNotBefore() {
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Min']));
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Day']));
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '2009-07-01 12:00:00']));
@@ -945,7 +943,7 @@ class QueuedJobsTableTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -321,11 +321,11 @@ class QueuedJobsTableTest extends TestCase {
 	}
 
 	/**
-     * Test creating Jobs to run close to a specified time, and strtotime parsing.
-     * Using toUnixString() function to convert Time object to timestamp, instead of strtotime
-     *
-     * @return void
-     */
+	 * Test creating Jobs to run close to a specified time, and strtotime parsing.
+	 * Using toUnixString() function to convert Time object to timestamp, instead of strtotime
+	 *
+	 * @return void
+	 */
 	public function testNotBefore() {
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Min']));
 		$this->assertTrue((bool)$this->QueuedJobs->createJob('Foo', null, ['notBefore' => '+ 1 Day']));

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -222,7 +222,7 @@ class ProcessorTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -222,7 +222,7 @@ class ProcessorTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -415,7 +415,7 @@ class EmailTaskTest extends TestCase {
 	 */
 	protected function _skipPostgres() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = str_contains((string) $config['driver'], 'Postgres');
+		$skip = str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only non Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/Queue/Task/EmailTaskTest.php
+++ b/tests/TestCase/Queue/Task/EmailTaskTest.php
@@ -415,7 +415,7 @@ class EmailTaskTest extends TestCase {
 	 */
 	protected function _skipPostgres() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Postgres') !== false;
+		$skip = str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only non Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -227,7 +227,7 @@ class QueueProgressHelperTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
+		$skip = !str_contains((string)$config['driver'], 'Mysql') && !str_contains((string)$config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/TestCase/View/Helper/QueueProgressHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueProgressHelperTest.php
@@ -227,7 +227,7 @@ class QueueProgressHelperTest extends TestCase {
 	 */
 	protected function _needsConnection() {
 		$config = ConnectionManager::getConfig('test');
-		$skip = strpos($config['driver'], 'Mysql') === false && strpos($config['driver'], 'Postgres') === false;
+		$skip = !str_contains((string) $config['driver'], 'Mysql') && !str_contains((string) $config['driver'], 'Postgres');
 		$this->skipIf($skip, 'Only Mysql/Postgres is working yet for this.');
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS === '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$fieldsObject = (new ReflectionClass($class))->getProperty('fields');
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.