### PR TITLE
Add optional stale-timeout to QueuedJobsTable::isQueued()

### DIFF
--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -276,14 +276,31 @@ class QueuedJobsTable extends Table {
 	}
 
 	/**
+	 * Whether a not-yet-completed job exists for the given reference.
+	 *
+	 * By default any row with `completed IS NULL` counts — including a job
+	 * that was fetched by a worker which then died (OOM, timeout, kill)
+	 * without ever marking the row completed or failed. Such a row stays
+	 * `completed IS NULL` indefinitely, so callers that gate on `isQueued()`
+	 * (e.g. a non-concurrent scheduler) can wedge permanently behind a job
+	 * that will never make progress.
+	 *
+	 * Pass `$staleTimeout` (seconds) to discount those abandoned rows: a row
+	 * that was fetched longer ago than the timeout and is still not completed
+	 * is presumed dead and no longer counts as queued. Rows that have not been
+	 * fetched yet, or were fetched within the window, still count. The default
+	 * `null` preserves the original behaviour and is fully backward compatible.
+	 *
 	 * @param string $reference
 	 * @param string|null $jobTask
+	 * @param int|null $staleTimeout Seconds after which a fetched-but-not-completed
+	 *   row is treated as abandoned and excluded. `null` (default) disables the check.
 	 *
 	 * @throws \InvalidArgumentException
 	 *
 	 * @return bool
 	 */
-	public function isQueued(string $reference, ?string $jobTask = null): bool {
+	public function isQueued(string $reference, ?string $jobTask = null, ?int $staleTimeout = null): bool {
 		if (!$reference) {
 			throw new InvalidArgumentException('A reference is needed');
 		}
@@ -294,6 +311,12 @@ class QueuedJobsTable extends Table {
 		];
 		if ($jobTask) {
 			$conditions['job_task'] = $jobTask;
+		}
+		if ($staleTimeout !== null) {
+			$conditions['OR'] = [
+				'fetched IS' => null,
+				'fetched >=' => $this->getDateTime()->subSeconds($staleTimeout),
+			];
 		}
 
 		return (bool)$this->find()->where($conditions)->select(['id'])->first();

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -835,6 +835,47 @@ class QueuedJobsTableTest extends TestCase {
 	}
 
 	/**
+	 * A job fetched longer ago than the stale timeout, but never completed,
+	 * is presumed abandoned and excluded once `$staleTimeout` is given.
+	 *
+	 * @return void
+	 */
+	public function testIsQueuedStaleTimeout() {
+		$queuedJob = $this->QueuedJobs->newEntity([
+			'key' => 'key',
+			'job_task' => 'FooBar',
+			'reference' => 'foo-bar',
+			'fetched' => (new DateTime())->subSeconds(120),
+		]);
+		$this->QueuedJobs->saveOrFail($queuedJob);
+
+		// Without the timeout the abandoned row still counts (unchanged default).
+		$this->assertTrue($this->QueuedJobs->isQueued('foo-bar'));
+
+		// Fetched 120s ago, timeout 60s => presumed dead, excluded.
+		$this->assertFalse($this->QueuedJobs->isQueued('foo-bar', null, 60));
+
+		// Fetched 120s ago, timeout 300s => still within window, counts.
+		$this->assertTrue($this->QueuedJobs->isQueued('foo-bar', null, 300));
+	}
+
+	/**
+	 * A not-yet-fetched job always counts as queued, regardless of timeout.
+	 *
+	 * @return void
+	 */
+	public function testIsQueuedStaleTimeoutIgnoresUnfetched() {
+		$queuedJob = $this->QueuedJobs->newEntity([
+			'key' => 'key',
+			'job_task' => 'FooBar',
+			'reference' => 'foo-bar',
+		]);
+		$this->QueuedJobs->saveOrFail($queuedJob);
+
+		$this->assertTrue($this->QueuedJobs->isQueued('foo-bar', null, 1));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testGetStats() {


### PR DESCRIPTION
## Problem

`QueuedJobsTable::isQueued()` counts any row with `completed IS NULL`. A job that a worker fetched and then died on (OOM, PHP timeout, container kill) without ever marking the row completed or failed stays `completed IS NULL` indefinitely.

Callers that gate on `isQueued()` then wedge behind that ghost row. The concrete case: a non-concurrent QueueScheduler row (`allow_concurrent = false`) checks `isQueued($reference, $task)` before dispatching the next run. Once a prior job is stuck "running" (fetched, never completed), every subsequent dispatch — cron and manual "Run" alike — is held back forever, even though nothing is actually executing.

## Change

Adds an optional `$staleTimeout` (seconds) parameter to `isQueued()`:

```php
public function isQueued(string $reference, ?string $jobTask = null, ?int $staleTimeout = null): bool
```

When provided, a row that was `fetched` longer ago than the timeout and is still not completed is presumed abandoned and excluded. Rows not yet fetched, and rows fetched within the window, still count.

`$staleTimeout` defaults to `null`, which preserves the exact original behaviour — fully backward compatible. Existing `testIsQueued()` is untouched and still passes.

## Tests

Added `testIsQueuedStaleTimeout()` and `testIsQueuedStaleTimeoutIgnoresUnfetched()` covering the fetched-but-abandoned, still-within-window, and never-fetched cases. Full `QueuedJobsTableTest` green; phpcs and phpstan clean on the changed file.
