### PR TITLE
Link dashboard stat cards to filtered lists; getLength aborted consistency

### DIFF
--- a/src/Model/Filter/QueuedJobsCollection.php
+++ b/src/Model/Filter/QueuedJobsCollection.php
@@ -54,6 +54,55 @@ class QueuedJobsCollection extends FilterCollection {
 
 						return true;
 					}
+					if ($status === 'pending') {
+						// Waiting to be picked up: never fetched, no failure, due,
+						// and not aborted. Mirrors the dashboard "Pending" card
+						// (totalPending minus running and retriable-failed).
+						$query->where([
+							'completed IS' => null,
+							'fetched IS' => null,
+							'failure_message IS' => null,
+							'AND' => [
+								[
+									'OR' => [
+										'notbefore <=' => new DateTime(),
+										'notbefore IS' => null,
+									],
+								],
+								[
+									'OR' => [
+										'status IS' => null,
+										'status !=' => QueuedJobsTable::STATUS_ABORTED,
+									],
+								],
+							],
+						]);
+
+						return true;
+					}
+					if ($status === 'running') {
+						// Picked up by a worker and not yet completed or failed.
+						$query->where([
+							'completed IS' => null,
+							'fetched IS NOT' => null,
+							'failure_message IS' => null,
+						]);
+
+						return true;
+					}
+					if ($status === 'failed') {
+						// Unfinished jobs with a recorded failure: still-retrying
+						// ones and terminally aborted ones alike.
+						$query->where(['completed IS' => null, 'failure_message IS NOT' => null]);
+
+						return true;
+					}
+					if ($status === 'aborted') {
+						// Terminally failed: retries exhausted, will never run again.
+						$query->where(['completed IS' => null, 'status' => QueuedJobsTable::STATUS_ABORTED]);
+
+						return true;
+					}
 
 					throw new NotImplementedException('Invalid status type');
 				},

--- a/src/Model/Table/QueuedJobsTable.php
+++ b/src/Model/Table/QueuedJobsTable.php
@@ -327,20 +327,12 @@ class QueuedJobsTable extends Table {
 	 * @return int
 	 */
 	public function getLength(?string $type = null): int {
-		$findConf = [
-			'conditions' => [
-				'completed IS' => null,
-				'OR' => [
-					'notbefore <=' => new DateTime(),
-					'notbefore IS' => null,
-				],
-			],
-		];
+		$conditions = $this->pendingConditions();
 		if ($type !== null) {
-			$findConf['conditions']['job_task'] = $type;
+			$conditions['job_task'] = $type;
 		}
 
-		return $this->find('all', ...$findConf)->count();
+		return $this->find('all', conditions: $conditions)->count();
 	}
 
 	/**

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -196,6 +196,7 @@ $stateMeta = [
 			'count' => $scheduledJobs,
 			'icon' => 'calendar',
 			'color' => 'info',
+			'link' => $this->Url->build(['action' => 'index', 'controller' => 'QueuedJobs', '?' => ['status' => 'scheduled']]),
 		]) ?>
 	</div>
 	<div class="col-md-3 col-sm-6">
@@ -204,6 +205,7 @@ $stateMeta = [
 			'count' => $pendingJobs,
 			'icon' => 'clock',
 			'color' => 'warning',
+			'link' => $this->Url->build(['action' => 'index', 'controller' => 'QueuedJobs', '?' => ['status' => 'pending']]),
 		]) ?>
 	</div>
 	<div class="col-md-3 col-sm-6">
@@ -212,6 +214,7 @@ $stateMeta = [
 			'count' => $runningJobs,
 			'icon' => 'spinner',
 			'color' => 'primary',
+			'link' => $this->Url->build(['action' => 'index', 'controller' => 'QueuedJobs', '?' => ['status' => 'running']]),
 		]) ?>
 	</div>
 	<div class="col-md-3 col-sm-6">
@@ -220,6 +223,7 @@ $stateMeta = [
 			'count' => $failedJobs,
 			'icon' => 'times-circle',
 			'color' => 'danger',
+			'link' => $this->Url->build(['action' => 'index', 'controller' => 'QueuedJobs', '?' => ['status' => 'failed']]),
 		]) ?>
 	</div>
 </div>

--- a/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueuedJobsControllerTest.php
@@ -263,6 +263,39 @@ JSON,
 	}
 
 	/**
+	 * The status filter supports running, failed and aborted in addition to
+	 * completed/in_progress/scheduled, so the dashboard stat cards can link to
+	 * the matching job list.
+	 *
+	 * @return void
+	 */
+	public function testIndexSearchByRunningFailedAborted() {
+		$this->createJob(['job_task' => 'waiting']);
+		$this->createJob(['job_task' => 'running', 'fetched' => new DateTime('-1 minute')]);
+		$this->createJob(['job_task' => 'failing', 'failure_message' => 'boom', 'attempts' => 1]);
+		$this->createJob(['job_task' => 'dead', 'failure_message' => 'boom', 'attempts' => 3, 'status' => 'aborted']);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'pending']]);
+		$this->assertResponseCode(200);
+		$tasks = collection($this->viewVariable('queuedJobs'))->extract('job_task')->toList();
+		$this->assertSame(['waiting'], $tasks);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'running']]);
+		$this->assertResponseCode(200);
+		$tasks = collection($this->viewVariable('queuedJobs'))->extract('job_task')->toList();
+		$this->assertSame(['running'], $tasks);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'failed']]);
+		$tasks = collection($this->viewVariable('queuedJobs'))->extract('job_task')->toList();
+		sort($tasks);
+		$this->assertSame(['dead', 'failing'], $tasks);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['status' => 'aborted']]);
+		$tasks = collection($this->viewVariable('queuedJobs'))->extract('job_task')->toList();
+		$this->assertSame(['dead'], $tasks);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testView() {

--- a/tests/TestCase/Model/Table/QueuedJobsTableTest.php
+++ b/tests/TestCase/Model/Table/QueuedJobsTableTest.php
@@ -904,6 +904,26 @@ class QueuedJobsTableTest extends TestCase {
 	}
 
 	/**
+	 * getLength() backs the dashboard "Pending Jobs (new/current)" card; it must
+	 * exclude aborted jobs so the card total stays consistent with the pending
+	 * list (getPendingStats()), which already excludes them.
+	 *
+	 * @return void
+	 */
+	public function testGetLengthExcludesAborted() {
+		$job = $this->QueuedJobs->newEntity([
+			'key' => 'key',
+			'job_task' => 'FooBar',
+			'reference' => 'len-one',
+		]);
+		$this->QueuedJobs->saveOrFail($job);
+		$this->assertSame(1, $this->QueuedJobs->getLength());
+
+		$this->QueuedJobs->markJobAborted($job);
+		$this->assertSame(0, $this->QueuedJobs->getLength());
+	}
+
+	/**
 	 * Resetting an aborted job for rerun must clear its terminal status so it
 	 * counts as pending again and gets picked up.
 	 *


### PR DESCRIPTION
## Summary

- `getLength()` now reuses `pendingConditions()` so it excludes terminally aborted jobs, consistent with `getPendingCount()`/`getPendingStats()` (from #505). Fixes the admin "Pending Jobs (new/current)" card header counting jobs the aborted-aware pending list below it did not contain.
- The `status` search filter gains `pending`, `running`, `failed`, and `aborted` values (alongside `completed`/`in_progress`/`scheduled`), each matching the corresponding dashboard stat-card count exactly.
- The Scheduled / Pending / Running / Failed stat cards are now clickable, linking to the job index filtered by the matching status (the `stats_card` element already accepted a `link`).

## Notes

- `pending` = waiting (completed null, not fetched, no failure, due, not aborted) — mirrors `$pendingJobs = totalPending - running - retriable-failed`.
- Tests: getLength excludes aborted; index filter returns the right set for pending/running/failed/aborted.