### PR TITLE
Dashboard status clarity: Requeued/Failed card + drop ambiguous Restarted label

### DIFF
--- a/src/View/Helper/QueueHelper.php
+++ b/src/View/Helper/QueueHelper.php
@@ -87,30 +87,6 @@ class QueueHelper extends Helper {
 	}
 
 	/**
-	 * Returns true if job has been manually restarted (reset).
-	 *
-	 * A restarted job has been fetched and has attempts, but no failure_message
-	 * (the failure_message was cleared when the job was reset).
-	 *
-	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
-	 *
-	 * @return bool
-	 */
-	public function isRestarted(QueuedJob $queuedJob): bool {
-		if ($queuedJob->completed || !$queuedJob->fetched) {
-			return false;
-		}
-
-		// Must have attempts (was previously run)
-		if ($queuedJob->attempts < 1) {
-			return false;
-		}
-
-		// Must NOT have a failure_message (it was cleared by reset)
-		return !$queuedJob->failure_message;
-	}
-
-	/**
 	 * Returns failure status (message) if applicable.
 	 *
 	 * @param \Queue\Model\Entity\QueuedJob $queuedJob
@@ -122,8 +98,11 @@ class QueueHelper extends Helper {
 			return null;
 		}
 
+		// No failure message yet: the job is simply running its current attempt,
+		// which is indistinguishable from a reset-and-rerun job, so there is no
+		// distinct failure status to report.
 		if (!$queuedJob->failure_message) {
-			return __d('queue', 'Restarted');
+			return null;
 		}
 
 		$taskConfig = $this->taskConfig($queuedJob->job_task);

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -219,7 +219,9 @@ $stateMeta = [
 	</div>
 	<div class="col-md-3 col-sm-6">
 		<?= $this->element('Queue.Queue/stats_card', [
-			'title' => __d('queue', 'Failed'),
+			// Counts every unfinished job with a failure_message: still-retrying
+			// (requeued) ones as well as terminally failed/aborted ones.
+			'title' => __d('queue', 'Requeued/Failed'),
 			'count' => $failedJobs,
 			'icon' => 'times-circle',
 			'color' => 'danger',

--- a/templates/Admin/Queue/index.php
+++ b/templates/Admin/Queue/index.php
@@ -303,11 +303,6 @@ $stateMeta = [
 													<i class="fas fa-redo me-1"></i><?= __d('queue', 'Requeued') ?>
 												</span>
 												<div class="small text-muted"><?= __d('queue', 'Attempts') ?>: <?= $this->Queue->attempts($pendingJob) ?></div>
-											<?php elseif ($this->Queue->isRestarted($pendingJob)): ?>
-												<span class="badge bg-info text-dark">
-													<i class="fas fa-sync me-1"></i><?= __d('queue', 'Restarted') ?>
-												</span>
-												<div class="small text-muted"><?= __d('queue', 'Attempts') ?>: <?= $this->Queue->attempts($pendingJob) ?></div>
 											<?php elseif ($pendingJob->fetched): ?>
 												<span class="badge badge-running">
 													<i class="fas fa-spinner fa-spin me-1"></i><?= __d('queue', 'Running') ?>

--- a/templates/Admin/QueuedJobs/index.php
+++ b/templates/Admin/QueuedJobs/index.php
@@ -153,10 +153,6 @@ if (Configure::read('Queue.isSearchEnabled') !== false && Plugin::isLoaded('Sear
 								<span class="badge bg-warning text-dark">
 									<i class="fas fa-redo me-1"></i><?= __d('queue', 'Requeued') ?>
 								</span>
-							<?php elseif ($this->Queue->isRestarted($queuedJob)): ?>
-								<span class="badge bg-info text-dark">
-									<i class="fas fa-sync me-1"></i><?= __d('queue', 'Restarted') ?>
-								</span>
 							<?php elseif ($queuedJob->fetched): ?>
 								<span class="badge badge-running">
 									<i class="fas fa-spinner fa-spin me-1"></i><?= __d('queue', 'Running') ?>

--- a/templates/Admin/QueuedJobs/view.php
+++ b/templates/Admin/QueuedJobs/view.php
@@ -254,10 +254,6 @@ use Brick\VarExporter\VarExporter;
 						<span class="badge bg-warning text-dark fs-6">
 							<i class="fas fa-redo me-1"></i><?= __d('queue', 'Requeued') ?>
 						</span>
-					<?php elseif ($this->Queue->isRestarted($queuedJob)): ?>
-						<span class="badge bg-info text-dark fs-6">
-							<i class="fas fa-sync me-1"></i><?= __d('queue', 'Restarted') ?>
-						</span>
 					<?php elseif ($queuedJob->fetched): ?>
 						<span class="badge badge-running fs-6">
 							<i class="fas fa-spinner fa-spin me-1"></i><?= __d('queue', 'Running') ?>

--- a/tests/TestCase/View/Helper/QueueHelperTest.php
+++ b/tests/TestCase/View/Helper/QueueHelperTest.php
@@ -105,7 +105,7 @@ class QueueHelperTest extends TestCase {
 
 		$queuedJob->failure_message = null;
 		$result = $this->QueueHelper->failureStatus($queuedJob);
-		$this->assertSame('Restarted', $result);
+		$this->assertNull($result);
 
 		$queuedJob->attempts = 999;
 		$queuedJob->failure_message = 'Foo';
@@ -219,66 +219,6 @@ class QueueHelperTest extends TestCase {
 			'failure_message' => 'Error',
 		]);
 		$this->assertFalse($this->QueueHelper->isRequeued($queuedJob));
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testIsRestarted(): void {
-		// Not fetched - not restarted
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => null,
-			'attempts' => 2,
-			'failure_message' => null,
-		]);
-		$this->assertFalse($this->QueueHelper->isRestarted($queuedJob));
-
-		// Completed - not restarted
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => new DateTime('-1 hour'),
-			'completed' => new DateTime(),
-			'attempts' => 2,
-			'failure_message' => null,
-		]);
-		$this->assertFalse($this->QueueHelper->isRestarted($queuedJob));
-
-		// No attempts - not restarted (first run)
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => new DateTime('-1 hour'),
-			'attempts' => 0,
-			'failure_message' => null,
-		]);
-		$this->assertFalse($this->QueueHelper->isRestarted($queuedJob));
-
-		// Has failure_message - not restarted (is requeued or failed)
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => new DateTime('-1 hour'),
-			'attempts' => 2,
-			'failure_message' => 'Error',
-		]);
-		$this->assertFalse($this->QueueHelper->isRestarted($queuedJob));
-
-		// Fetched, has attempts, NO failure_message - IS restarted
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => new DateTime('-1 hour'),
-			'attempts' => 2,
-			'failure_message' => null,
-		]);
-		$this->assertTrue($this->QueueHelper->isRestarted($queuedJob));
-
-		// Also restarted with just 1 attempt
-		$queuedJob = new QueuedJob([
-			'job_task' => 'Queue.Example',
-			'fetched' => new DateTime('-1 hour'),
-			'attempts' => 1,
-			'failure_message' => null,
-		]);
-		$this->assertTrue($this->QueueHelper->isRestarted($queuedJob));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two related admin-dashboard status-label fixes:

1. **Requeued/Failed card** — the "Failed" stat card counts `completed IS NULL AND failure_message IS NOT NULL`, which includes still-retrying (requeued, attempts <= retries) jobs as well as terminally failed/aborted ones. A job on attempt 1/2 therefore showed under a plain "Failed" heading. Relabeled to **Requeued/Failed** to match what it counts (the `?status=failed` link already targets this set).

2. **Drop the ambiguous "Restarted" label** — `isRestarted()` flagged any `fetched + attempts>=1 + no failure_message` job as Restarted, but that is exactly a fresh job running its first attempt (just fetched, attempts incremented to 1, never failed). So every in-progress first-attempt job was mislabeled "Restarted". The state is undetectable anyway: `reset()` clears `fetched`/`attempts` to 0, so a re-picked-up reset job is identical to a first run. Removed `isRestarted()`, the Restarted branch in `failureStatus()`, and the Restarted badge in the admin templates — such jobs now correctly show **Running**.

## Notes

- Tests updated (failureStatus no-failure case now null; isRestarted test removed).