### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/QueueProgressHelper.php
+++ b/src/View/Helper/QueueProgressHelper.php
@@ -20,7 +20,7 @@ class QueueProgressHelper extends Helper {
 	use LocatorAwareTrait;
 
 	/**
-	 * @var array<mixed>
+	 * @var array<int|string, array<string, mixed>|string>
 	 */
 	protected array $helpers = [
 		'Tools.Progress',


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test